### PR TITLE
Show firstPrompt as session subtitle in sidebar

### DIFF
--- a/Poirot/Sources/Models/Session.swift
+++ b/Poirot/Sources/Models/Session.swift
@@ -11,6 +11,7 @@ nonisolated struct Session: Identifiable, Hashable {
     let cachedTitle: String?
     let cachedPreview: String?
     let cachedTurnCount: Int?
+    let firstPrompt: String?
 
     init(
         id: String,
@@ -22,7 +23,8 @@ nonisolated struct Session: Identifiable, Hashable {
         fileURL: URL? = nil,
         cachedTitle: String? = nil,
         cachedPreview: String? = nil,
-        cachedTurnCount: Int? = nil
+        cachedTurnCount: Int? = nil,
+        firstPrompt: String? = nil
     ) {
         self.id = id
         self.projectPath = projectPath
@@ -34,6 +36,7 @@ nonisolated struct Session: Identifiable, Hashable {
         self.cachedTitle = cachedTitle
         self.cachedPreview = cachedPreview
         self.cachedTurnCount = cachedTurnCount
+        self.firstPrompt = firstPrompt
     }
 
     var projectName: String {

--- a/Poirot/Sources/Services/SessionLoader.swift
+++ b/Poirot/Sources/Services/SessionLoader.swift
@@ -114,7 +114,8 @@ nonisolated struct SessionLoader: SessionLoading {
                     fileURL: fileURL,
                     projectPath: projectPath,
                     sessionId: entry.sessionId,
-                    indexStartedAt: indexStartedAt
+                    indexStartedAt: indexStartedAt,
+                    firstPrompt: entry.firstPrompt
                 ) {
                     sessions.append(session)
                 }

--- a/Poirot/Sources/Services/TranscriptParser.swift
+++ b/Poirot/Sources/Services/TranscriptParser.swift
@@ -231,7 +231,8 @@ nonisolated struct TranscriptParser {
         fileURL: URL,
         projectPath: String,
         sessionId: String,
-        indexStartedAt: Date?
+        indexStartedAt: Date?,
+        firstPrompt: String? = nil
     ) -> Session? {
         guard let data = try? Data(contentsOf: fileURL) else { return nil }
         guard let text = String(data: data, encoding: .utf8), !text.isEmpty else { return nil }
@@ -319,7 +320,8 @@ nonisolated struct TranscriptParser {
             fileURL: fileURL,
             cachedTitle: firstUserText,
             cachedPreview: firstAssistantText,
-            cachedTurnCount: userCount
+            cachedTurnCount: userCount,
+            firstPrompt: firstPrompt
         )
     }
 

--- a/Poirot/Sources/Views/Components/SidebarView.swift
+++ b/Poirot/Sources/Views/Components/SidebarView.swift
@@ -447,18 +447,28 @@ private struct SessionRow: View {
             guard state.selectedSession?.id != session.id else { return }
             state.selectedSession = session
         } label: {
-            HStack {
-                MarqueeText(text: session.title, font: PoirotTheme.Typography.caption, highlightQuery: highlightQuery)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    MarqueeText(text: session.title, font: PoirotTheme.Typography.caption, highlightQuery: highlightQuery)
 
-                Spacer()
+                    Spacer()
 
-                if isHovered || isMenuPresented {
-                    sessionMenu
-                        .transition(.opacity)
-                } else {
-                    Text(session.timeAgo)
+                    if isHovered || isMenuPresented {
+                        sessionMenu
+                            .transition(.opacity)
+                    } else {
+                        Text(session.timeAgo)
+                            .font(PoirotTheme.Typography.tiny)
+                            .foregroundStyle(PoirotTheme.Colors.textTertiary)
+                    }
+                }
+
+                if let firstPrompt = session.firstPrompt, !firstPrompt.isEmpty {
+                    Text(firstPrompt)
                         .font(PoirotTheme.Typography.tiny)
                         .foregroundStyle(PoirotTheme.Colors.textTertiary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                 }
             }
             .padding(.vertical, 5)

--- a/PoirotTests/Models/SessionTests.swift
+++ b/PoirotTests/Models/SessionTests.swift
@@ -217,4 +217,54 @@ struct SessionTests {
         )
         #expect(session.fileURL == url)
     }
+
+    // MARK: - First Prompt
+
+    @Test
+    func firstPrompt_defaultsToNil() {
+        let session = Session(id: "fp1", projectPath: "/path", messages: [], startedAt: .now, model: nil, totalTokens: 0)
+        #expect(session.firstPrompt == nil)
+    }
+
+    @Test
+    func firstPrompt_preservesValue() {
+        let session = Session(
+            id: "fp2",
+            projectPath: "/path",
+            messages: [],
+            startedAt: .now,
+            model: nil,
+            totalTokens: 0,
+            firstPrompt: "Fix the login bug"
+        )
+        #expect(session.firstPrompt == "Fix the login bug")
+    }
+
+    @Test
+    func firstPrompt_preservesNilExplicitly() {
+        let session = Session(
+            id: "fp3",
+            projectPath: "/path",
+            messages: [],
+            startedAt: .now,
+            model: nil,
+            totalTokens: 0,
+            firstPrompt: nil
+        )
+        #expect(session.firstPrompt == nil)
+    }
+
+    @Test
+    func firstPrompt_preservesEmptyString() {
+        let session = Session(
+            id: "fp4",
+            projectPath: "/path",
+            messages: [],
+            startedAt: .now,
+            model: nil,
+            totalTokens: 0,
+            firstPrompt: ""
+        )
+        #expect(session.firstPrompt == "")
+    }
 }

--- a/PoirotTests/Services/SessionLoaderTests.swift
+++ b/PoirotTests/Services/SessionLoaderTests.swift
@@ -402,4 +402,95 @@ struct SessionLoaderTests {
         #expect(session.title == "Fallback title")
         #expect(session.fileURL != nil)
     }
+
+    // MARK: - First Prompt
+
+    @Test
+    func discoverProjects_indexPath_passesFirstPromptToSession() throws {
+        let tmpDir = try makeTempProjectDir()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let sessionId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        let indexJSON = """
+        {
+            "version": 1,
+            "entries": [
+                {
+                    "sessionId": "\(sessionId)",
+                    "created": "2026-01-28T10:00:00.000Z",
+                    "isSidechain": false,
+                    "projectPath": "/test/project",
+                    "firstPrompt": "Fix the login bug"
+                }
+            ]
+        }
+        """
+
+        try makeProjectWithJSONL(
+            in: tmpDir,
+            projectDirName: "test-project",
+            sessionId: sessionId,
+            jsonlContent: simpleJSONL(),
+            indexJSON: indexJSON
+        )
+
+        let loader = SessionLoader(claudeProjectsPath: tmpDir.path)
+        let projects = try loader.discoverProjects()
+        let session = projects[0].sessions[0]
+        #expect(session.firstPrompt == "Fix the login bug")
+    }
+
+    @Test
+    func discoverProjects_indexPath_nilFirstPromptWhenMissing() throws {
+        let tmpDir = try makeTempProjectDir()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let sessionId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        let indexJSON = """
+        {
+            "version": 1,
+            "entries": [
+                {
+                    "sessionId": "\(sessionId)",
+                    "created": "2026-01-28T10:00:00.000Z",
+                    "isSidechain": false,
+                    "projectPath": "/test/project"
+                }
+            ]
+        }
+        """
+
+        try makeProjectWithJSONL(
+            in: tmpDir,
+            projectDirName: "test-project",
+            sessionId: sessionId,
+            jsonlContent: simpleJSONL(),
+            indexJSON: indexJSON
+        )
+
+        let loader = SessionLoader(claudeProjectsPath: tmpDir.path)
+        let projects = try loader.discoverProjects()
+        let session = projects[0].sessions[0]
+        #expect(session.firstPrompt == nil)
+    }
+
+    @Test
+    func discoverProjects_fallbackPath_firstPromptIsNil() throws {
+        let tmpDir = try makeTempProjectDir()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let sessionId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        // No index — forces fallback path
+        try makeProjectWithJSONL(
+            in: tmpDir,
+            projectDirName: "test-project",
+            sessionId: sessionId,
+            jsonlContent: simpleJSONL()
+        )
+
+        let loader = SessionLoader(claudeProjectsPath: tmpDir.path)
+        let projects = try loader.discoverProjects()
+        let session = projects[0].sessions[0]
+        #expect(session.firstPrompt == nil)
+    }
 }


### PR DESCRIPTION
## Summary
- Wire `firstPrompt` from `SessionsIndex.Entry` through the model and loader into `SidebarView`
- Display it as a secondary subtitle line beneath the session title, truncated to one line
- Add 7 unit tests covering model defaults, value preservation, and loader passthrough

Closes #22