### PR TITLE
Fix skill frontmatter parsing and config back navigation

### DIFF
--- a/Poirot/Sources/App/AppState.swift
+++ b/Poirot/Sources/App/AppState.swift
@@ -48,6 +48,7 @@ struct ConfigDetailInfo: Equatable {
 
 enum NavigationEntry: Equatable {
     case session(Session)
+    case configList(navItemID: String)
     case configDetail(navItemID: String, detail: ConfigDetailInfo)
 }
 
@@ -149,6 +150,12 @@ final class AppState {
         if navigationHistoryIndex < navigationHistory.count - 1 {
             navigationHistory.removeSubrange((navigationHistoryIndex + 1)...)
         }
+        // Push a list entry first so the back button has somewhere to go
+        let currentEntry = navigationHistoryIndex >= 0 ? navigationHistory[navigationHistoryIndex] : nil
+        if currentEntry != .configList(navItemID: navItemID) {
+            navigationHistory.append(.configList(navItemID: navItemID))
+            navigationHistoryIndex = navigationHistory.count - 1
+        }
         let entry = NavigationEntry.configDetail(navItemID: navItemID, detail: detail)
         navigationHistory.append(entry)
         navigationHistoryIndex = navigationHistory.count - 1
@@ -160,6 +167,12 @@ final class AppState {
             selectedNav = .sessions
             activeConfigDetail = nil
             selectedSession = session
+        case let .configList(navItemID):
+            if let navItem = NavigationItem.allItems.first(where: { $0.id == navItemID }) {
+                selectedNav = navItem
+            }
+            selectedSession = nil
+            activeConfigDetail = nil
         case let .configDetail(navItemID, detail):
             if let navItem = NavigationItem.allItems.first(where: { $0.id == navItemID }) {
                 selectedNav = navItem

--- a/Poirot/Sources/Services/Config/FrontmatterParser.swift
+++ b/Poirot/Sources/Services/Config/FrontmatterParser.swift
@@ -21,15 +21,50 @@ enum FrontmatterParser {
         let body = String(afterOpening[closeRange.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
 
         var metadata: [String: String] = [:]
-        for line in yamlBlock.components(separatedBy: .newlines) {
+        var currentBlockKey: String?
+        var blockLines: [String] = []
+        var blockIsFolded = true
+
+        let lines = yamlBlock.components(separatedBy: .newlines)
+        for line in lines {
             let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+
+            // Continuation line for a block scalar (indented under `>` or `|`)
+            if currentBlockKey != nil, !trimmedLine.isEmpty,
+               line.first?.isWhitespace == true, !trimmedLine.contains(":") || line.hasPrefix("  ") {
+                blockLines.append(trimmedLine)
+                continue
+            }
+
+            // Flush any pending block scalar
+            if let key = currentBlockKey {
+                let separator = blockIsFolded ? " " : "\n"
+                metadata[key] = blockLines.joined(separator: separator)
+                currentBlockKey = nil
+                blockLines = []
+            }
+
             guard !trimmedLine.isEmpty else { continue }
             guard let colonIndex = trimmedLine.firstIndex(of: ":") else { continue }
             let key = String(trimmedLine[trimmedLine.startIndex ..< colonIndex])
                 .trimmingCharacters(in: .whitespaces)
             let value = String(trimmedLine[trimmedLine.index(after: colonIndex)...])
                 .trimmingCharacters(in: .whitespaces)
-            metadata[key] = value
+
+            // Start a block scalar
+            if value == ">" || value == "|" {
+                currentBlockKey = key
+                blockIsFolded = value == ">"
+                blockLines = []
+            } else {
+                metadata[key] = value
+            }
+        }
+
+        // Flush trailing block scalar
+        if let key = currentBlockKey {
+            let separator = blockIsFolded ? " " : "\n"
+            metadata[key] = blockLines.joined(separator: separator)
         }
 
         return Result(metadata: metadata, body: body)

--- a/PoirotTests/Services/FrontmatterParserTests.swift
+++ b/PoirotTests/Services/FrontmatterParserTests.swift
@@ -118,4 +118,45 @@ struct FrontmatterParserTests {
         #expect(result.metadata["key"] == "value")
         #expect(result.body.isEmpty)
     }
+
+    // MARK: - Block Scalar Folded (>)
+
+    @Test
+    func parse_foldedBlockScalar_joinsWithSpaces() {
+        let input = "---\nname: my-skill\ndescription: >\n  Multi-line description\n  goes here\n---\nBody"
+        let result = FrontmatterParser.parse(input)
+        #expect(result.metadata["name"] == "my-skill")
+        #expect(result.metadata["description"] == "Multi-line description goes here")
+        #expect(result.body == "Body")
+    }
+
+    // MARK: - Block Scalar Literal (|)
+
+    @Test
+    func parse_literalBlockScalar_joinsWithNewlines() {
+        let input = "---\nname: my-skill\ndescription: |\n  Line one\n  Line two\n---\nBody"
+        let result = FrontmatterParser.parse(input)
+        #expect(result.metadata["name"] == "my-skill")
+        #expect(result.metadata["description"] == "Line one\nLine two")
+    }
+
+    // MARK: - Block Scalar Followed By Another Key
+
+    @Test
+    func parse_blockScalarFollowedByKey_bothExtracted() {
+        let input = "---\ndescription: >\n  A long\n  description\nmodel: opus\n---\nBody"
+        let result = FrontmatterParser.parse(input)
+        #expect(result.metadata["description"] == "A long description")
+        #expect(result.metadata["model"] == "opus")
+    }
+
+    // MARK: - Block Scalar At End Of YAML
+
+    @Test
+    func parse_blockScalarAtEnd_extracted() {
+        let input = "---\nname: test\nallowed-tools: >\n  Bash, Read,\n  Glob, Grep\n---\nBody"
+        let result = FrontmatterParser.parse(input)
+        #expect(result.metadata["name"] == "test")
+        #expect(result.metadata["allowed-tools"] == "Bash, Read, Glob, Grep")
+    }
 }


### PR DESCRIPTION
## Summary
- Fix YAML block scalar parsing (`>` folded, `|` literal) in FrontmatterParser — skills using multi-line `description: >` syntax now show the full description instead of just `>`
- Fix config detail back button by pushing a `configList` history entry before the detail entry, so there's always a parent to navigate back to

## Root Causes
1. **Frontmatter**: Parser only handled single-line `key: value` pairs. Block scalars like `description: >\n  text` stored `>` as the value instead of collecting continuation lines
2. **Back nav**: `pushConfigDetail()` only added one history entry (the detail). With `canNavigateBack` requiring `index > 0`, the back button was always disabled for the first detail view

## Test plan
- [x] 4 new FrontmatterParser tests (folded, literal, followed-by-key, end-of-yaml)
- [x] All 313 unit tests pass
- [ ] CI passes
- [ ] Manual: Open skills with block scalar frontmatter — description renders correctly
- [ ] Manual: Click a skill → click back → returns to list