### PR TITLE
docs: split README screenshots into SHOWCASE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,145 +52,36 @@ Named after **Hercule Poirot**, Agatha Christie's legendary detective. Because e
 
 ## Features
 
-### Session Analytics
-Track your Claude Code usage with visual dashboards. See token consumption, cost breakdowns, model distribution, and session trends — all computed locally from your transcript data.
-
 <p align="center">
   <img src="assets/showcase/02-analytics.png" alt="Session Analytics" width="720" />
 </p>
-
-### Session History Browser
-Browse all your Claude Code sessions grouped by project. Timestamps, token counts, model info — everything at a glance in a sidebar you'd expect from a native macOS app.
-
-<p align="center">
-  <img src="assets/showcase/10-session-browser.png" alt="Session History Browser" width="720" />
-</p>
-
-### Rich Conversation View
-Full conversation timeline with user messages, assistant responses, and collapsible tool blocks. Markdown rendering with syntax highlighting, because raw JSONL is not fun to read.
 
 <p align="center">
   <img src="assets/showcase/04-conversation.png" alt="Rich Conversation View" width="720" />
 </p>
 
-### Tool Block Display
-Every tool invocation — Read, Edit, Bash, Write — rendered with its name, icon, file path, and result. Collapsible, copyable, and with smart truncation for long outputs.
+- **Session Analytics** — Token consumption, cost breakdowns, model distribution, and session trends
+- **Session History Browser** — Sessions grouped by project with timestamps, model info, and token counts
+- **Rich Conversation View** — Full timeline with markdown rendering, syntax highlighting, and collapsible tool blocks
+- **Tool Block Display** — Every tool invocation rendered with name, icon, file path, and result
+- **Extended Thinking** — Collapsible thinking blocks with distinct purple accent
+- **Fuzzy Search (&#x2318;K)** — Spotlight-style search across sessions, commands, file paths, and more
+- **Slash Commands** — Browse global and per-project commands with descriptions and permissions
+- **Skills** — Explore reusable skill modules with parsed frontmatter
+- **MCP Servers** — Live connection status indicators with color-coded SF Symbols
+- **Models** — Browse available models and their capabilities
+- **Sub-agents** — Inspect built-in sub-agent configurations
+- **Plugins** — View installed plugins and their metadata
+- **Output Styles** — Preview output formatting styles
+- **Hooks** — Event hooks grouped by type with matcher patterns and handler details
+- **Session TODOs** — Per-session todo lists with status tracking
+- **Plans** — Browse `~/.claude/plans/` with rendered markdown and file watching
+- **Debug Log Viewer** — Color-coded log levels, search, filtering, and paginated loading
+- **Prompt History** — Browse input history with date grouping and project filtering
+- **AI Session Summaries** — Goal, outcome, helpfulness, and friction indicators from facets
+- **Memory** — Per-project auto-memory files with rendered markdown and live watching
 
-<p align="center">
-  <img src="assets/showcase/05-tool-blocks.png" alt="Tool Blocks" width="720" />
-</p>
-
-### Extended Thinking
-See Claude's thinking process with collapsible thinking blocks, styled with a distinct purple accent so you can tell reasoning from response.
-
-<p align="center">
-  <img src="assets/showcase/06-thinking.png" alt="Extended Thinking" width="720" />
-</p>
-
-### Fuzzy Search (&#x2318;K)
-Search across all sessions, commands, and file paths. A spotlight-style overlay that gets you where you need to go.
-
-<p align="center">
-  <img src="assets/showcase/09-search.png" alt="Fuzzy Search" width="720" />
-</p>
-
-### Slash Commands
-Browse and inspect all your slash commands — global ones from `~/.claude/commands/` and project-scoped ones from `.claude/commands/`. See descriptions, arguments, model assignments, and tool permissions at a glance.
-
-<p align="center">
-  <img src="assets/showcase/11-commands.png" alt="Slash Commands" width="720" />
-</p>
-
-### Skills
-Explore reusable skill modules with their full documentation. Skills are rendered with markdown frontmatter parsed into structured cards showing descriptions and references.
-
-<p align="center">
-  <img src="assets/showcase/13-skills.png" alt="Skills" width="720" />
-</p>
-
-### MCP Servers
-See all configured Model Context Protocol servers with their connection details, tool counts, and scope badges. Quickly check which servers are available globally vs. per-project. Each server displays a live connection status indicator — Connected, Needs Auth, Failed, Unreachable, Starting, or Unknown — with color-coded SF Symbols and animated effects. Status updates automatically by watching the config and auth cache files.
-
-<p align="center">
-  <img src="assets/showcase/12-mcp-servers.png" alt="MCP Servers" width="720" />
-</p>
-
-### Models
-Browse all available models with their capabilities. See which model is set as the default and compare options across providers.
-
-<p align="center">
-  <img src="assets/showcase/15-models.png" alt="Models" width="720" />
-</p>
-
-### Sub-agents
-Inspect built-in sub-agent configurations. See agent names, descriptions, and how they're wired into your workflow.
-
-<p align="center">
-  <img src="assets/showcase/16-sub-agents.png" alt="Sub-agents" width="720" />
-</p>
-
-### Plugins
-View all installed Claude plugins with their metadata. Check what's active, discover available extensions, and see plugin details at a glance.
-
-<p align="center">
-  <img src="assets/showcase/17-plugins.png" alt="Plugins" width="720" />
-</p>
-
-### Output Styles
-Browse and preview output formatting styles. See how each style shapes Claude's responses and which one is currently active.
-
-<p align="center">
-  <img src="assets/showcase/18-output-styles.png" alt="Output Styles" width="720" />
-</p>
-
-### Hooks
-View and manage hooks that automate tasks during Claude Code events. See all configured hooks grouped by event type (PreToolUse, PostToolUse, Notification, etc.), with matcher patterns, handler types, and scope badges.
-
-<p align="center">
-  <img src="assets/showcase/24-hooks.png" alt="Hooks" width="720" />
-</p>
-
-### Session TODOs
-See all Claude Code per-session todo lists at a glance. Cards show task status (pending, in progress, completed), and you can jump straight to the associated session or delete orphaned entries.
-
-<p align="center">
-  <img src="assets/showcase/19-todos.png" alt="Session TODOs" width="720" />
-</p>
-
-### Plans
-Browse your `~/.claude/plans/` markdown files with rendered markdown or raw text views. Copy content, delete files, and search across all plans — with real-time file watching so new plans appear automatically.
-
-<p align="center">
-  <img src="assets/showcase/20-plans.png" alt="Plans" width="720" />
-</p>
-
-### Debug Log Viewer
-Diagnose MCP server issues, permission failures, and startup problems with the per-session debug log viewer. Accessible from the session toolbar, it parses `~/.claude/debug/<sessionId>.txt` files with color-coded log levels (DEBUG in gray, WARN in amber, ERROR in red), full-text search, level filtering, and auto-scroll to the first error. Logs are lazily loaded with paginated fetching for smooth performance on large files. Toggle between absolute and relative timestamps, and copy the full log for sharing in bug reports. Searchable via the universal search overlay.
-
-<p align="center">
-  <img src="assets/showcase/21-debug-log.png" alt="Debug Log Viewer" width="720" />
-</p>
-
-### Prompt History
-Browse your entire Claude Code input history from `~/.claude/history.jsonl`. Prompts are grouped by date (Today, Yesterday, This Week, etc.), filterable by project, and searchable with full-text fuzzy matching. Copy any prompt to clipboard for reuse. Live file watching keeps the view up to date.
-
-<p align="center">
-  <img src="assets/showcase/21-history.png" alt="Prompt History" width="720" />
-</p>
-
-### AI Session Summaries
-See AI-generated session analysis at the top of each session detail. A collapsible card shows the brief summary, underlying goal, outcome badge, helpfulness rating, session type, goal categories as tags, and friction indicators — all parsed from `~/.claude/usage-data/facets/`. Facets are also searchable via the universal search overlay.
-
-<p align="center">
-  <img src="assets/showcase/22-ai-summaries.png" alt="AI Session Summaries" width="720" />
-</p>
-
-### Memory
-Browse Claude Code's auto-memory files per project. MEMORY.md is the main entrypoint loaded into every conversation, and topic files contain detailed notes organized by subject. Filter by project, view rendered markdown, and search across all memories with live file watching.
-
-<p align="center">
-  <img src="assets/showcase/23-memory.png" alt="Memory" width="720" />
-</p>
+> **See all features with screenshots in the [Feature Showcase](SHOWCASE.md).**
 
 ---
 
@@ -209,7 +100,7 @@ Browse Claude Code's auto-memory files per project. MEMORY.md is the main entryp
 | | Bash Output Renderer | Terminal command output with monospace styling and exit status |
 | | Extended Thinking | Collapsible thinking blocks with distinct purple accent |
 | | Tool Blocks | Every tool invocation rendered with name, icon, file path, and result |
-| | In-Session Search | ⌘F to search within the current conversation |
+| | In-Session Search | &#x2318;F to search within the current conversation |
 | **Diagnostics** | Debug Log Viewer | Parse and browse `~/.claude/debug/` logs with color-coded levels, search, filtering, and paginated lazy loading |
 | | Auto-scroll to Error | Opens directly at the first error entry for quick triage |
 | | Relative Timestamps | Toggle between absolute (HH:mm:ss.SSS) and relative (+offset) time display |
@@ -219,7 +110,7 @@ Browse Claude Code's auto-memory files per project. MEMORY.md is the main entryp
 | | Goal Categories | Tag chips showing categorized session goals with counts |
 | | Friction Indicators | Subtle indicators for tool failures, misunderstandings, and other friction |
 | | Live File Watching | Auto-updates when new facets appear via GCD dispatch sources |
-| **Search** | Universal Search (⌘K) | Fuzzy search across sessions, AI summaries, history, commands, skills, memory, MCP servers, plugins, output styles, models, sub-agents, plans, TODOs, and debug logs |
+| **Search** | Universal Search (&#x2318;K) | Fuzzy search across sessions, AI summaries, history, commands, skills, memory, MCP servers, plugins, output styles, models, sub-agents, plans, TODOs, and debug logs |
 | | Grouped Results | Results organized by category with counts |
 | | Quick Access | Empty state shows shortcuts, counts, and recent sessions |
 | **Configuration** | Commands | Browse and manage slash commands (global and per-project) |
@@ -241,9 +132,9 @@ Browse Claude Code's auto-memory files per project. MEMORY.md is the main entryp
 | **Export** | Session Export | Export sessions as Markdown or PDF with configurable options |
 | | Copy Markdown | One-click copy of session content as Markdown to clipboard |
 | | Share Sheet | Native macOS share sheet integration for exported files |
-| **Navigation** | Font Scaling | ⌘+ / ⌘- / ⌘0 to zoom the entire UI |
+| **Navigation** | Font Scaling | &#x2318;+ / &#x2318;- / &#x2318;0 to zoom the entire UI |
 | | Keyboard-First | Vim-style j/k/gg/G, Tab panel cycling, `/` search, `?` shortcut help sheet |
-| | Help Book (⌘?) | Keyboard reference, feature overview, and getting started guide |
+| | Help Book (&#x2318;?) | Keyboard reference, feature overview, and getting started guide |
 | **App** | Onboarding Flow | First-run welcome with CLI detection, session discovery, and feature tour |
 | | Homebrew Distribution | `brew install --cask poirot` with automated release workflow |
 | **Design** | Dark Theme | Warm golden accent (`#E8A642`) on near-black backgrounds |
@@ -425,14 +316,6 @@ MIT — see [LICENSE](LICENSE) for details.
 No tracking. No analytics. Analyze the code yourself, or ask your Claude to do it. :)
 
 Made with coffee and Claude Code in a weekend.
-
-<p align="center">
-  <a href="https://youtu.be/JLvNSRZrxdo">
-    <img src="https://img.youtube.com/vi/JLvNSRZrxdo/maxresdefault.jpg" alt="Poirot Demo Video" width="720" />
-  </a>
-  <br/>
-  <sub>Click to watch the demo on YouTube</sub>
-</p>
 
 <p align="center">
   <sub>If you find Poirot useful, consider giving it a star. It helps others discover the project.</sub>

--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -1,0 +1,186 @@
+<h1 align="center">POIROT — Feature Showcase</h1>
+
+<p align="center">
+  <strong>A visual tour of every feature in Poirot.</strong><br/>
+  For installation, architecture, and contributing info, see the <a href="README.md">README</a>.
+</p>
+
+---
+
+## Session Analytics
+Track your Claude Code usage with visual dashboards. See token consumption, cost breakdowns, model distribution, and session trends — all computed locally from your transcript data.
+
+<p align="center">
+  <img src="assets/showcase/02-analytics.png" alt="Session Analytics" width="720" />
+</p>
+
+---
+
+## Session History Browser
+Browse all your Claude Code sessions grouped by project. Timestamps, token counts, model info — everything at a glance in a sidebar you'd expect from a native macOS app.
+
+<p align="center">
+  <img src="assets/showcase/10-session-browser.png" alt="Session History Browser" width="720" />
+</p>
+
+---
+
+## Rich Conversation View
+Full conversation timeline with user messages, assistant responses, and collapsible tool blocks. Markdown rendering with syntax highlighting, because raw JSONL is not fun to read.
+
+<p align="center">
+  <img src="assets/showcase/04-conversation.png" alt="Rich Conversation View" width="720" />
+</p>
+
+---
+
+## Tool Block Display
+Every tool invocation — Read, Edit, Bash, Write — rendered with its name, icon, file path, and result. Collapsible, copyable, and with smart truncation for long outputs.
+
+<p align="center">
+  <img src="assets/showcase/05-tool-blocks.png" alt="Tool Blocks" width="720" />
+</p>
+
+---
+
+## Extended Thinking
+See Claude's thinking process with collapsible thinking blocks, styled with a distinct purple accent so you can tell reasoning from response.
+
+<p align="center">
+  <img src="assets/showcase/06-thinking.png" alt="Extended Thinking" width="720" />
+</p>
+
+---
+
+## Fuzzy Search (&#x2318;K)
+Search across all sessions, commands, and file paths. A spotlight-style overlay that gets you where you need to go.
+
+<p align="center">
+  <img src="assets/showcase/09-search.png" alt="Fuzzy Search" width="720" />
+</p>
+
+---
+
+## Slash Commands
+Browse and inspect all your slash commands — global ones from `~/.claude/commands/` and project-scoped ones from `.claude/commands/`. See descriptions, arguments, model assignments, and tool permissions at a glance.
+
+<p align="center">
+  <img src="assets/showcase/11-commands.png" alt="Slash Commands" width="720" />
+</p>
+
+---
+
+## Skills
+Explore reusable skill modules with their full documentation. Skills are rendered with markdown frontmatter parsed into structured cards showing descriptions and references.
+
+<p align="center">
+  <img src="assets/showcase/13-skills.png" alt="Skills" width="720" />
+</p>
+
+---
+
+## MCP Servers
+See all configured Model Context Protocol servers with their connection details, tool counts, and scope badges. Quickly check which servers are available globally vs. per-project. Each server displays a live connection status indicator — Connected, Needs Auth, Failed, Unreachable, Starting, or Unknown — with color-coded SF Symbols and animated effects. Status updates automatically by watching the config and auth cache files.
+
+<p align="center">
+  <img src="assets/showcase/12-mcp-servers.png" alt="MCP Servers" width="720" />
+</p>
+
+---
+
+## Models
+Browse all available models with their capabilities. See which model is set as the default and compare options across providers.
+
+<p align="center">
+  <img src="assets/showcase/15-models.png" alt="Models" width="720" />
+</p>
+
+---
+
+## Sub-agents
+Inspect built-in sub-agent configurations. See agent names, descriptions, and how they're wired into your workflow.
+
+<p align="center">
+  <img src="assets/showcase/16-sub-agents.png" alt="Sub-agents" width="720" />
+</p>
+
+---
+
+## Plugins
+View all installed Claude plugins with their metadata. Check what's active, discover available extensions, and see plugin details at a glance.
+
+<p align="center">
+  <img src="assets/showcase/17-plugins.png" alt="Plugins" width="720" />
+</p>
+
+---
+
+## Output Styles
+Browse and preview output formatting styles. See how each style shapes Claude's responses and which one is currently active.
+
+<p align="center">
+  <img src="assets/showcase/18-output-styles.png" alt="Output Styles" width="720" />
+</p>
+
+---
+
+## Hooks
+View and manage hooks that automate tasks during Claude Code events. See all configured hooks grouped by event type (PreToolUse, PostToolUse, Notification, etc.), with matcher patterns, handler types, and scope badges.
+
+<p align="center">
+  <img src="assets/showcase/24-hooks.png" alt="Hooks" width="720" />
+</p>
+
+---
+
+## Session TODOs
+See all Claude Code per-session todo lists at a glance. Cards show task status (pending, in progress, completed), and you can jump straight to the associated session or delete orphaned entries.
+
+<p align="center">
+  <img src="assets/showcase/19-todos.png" alt="Session TODOs" width="720" />
+</p>
+
+---
+
+## Plans
+Browse your `~/.claude/plans/` markdown files with rendered markdown or raw text views. Copy content, delete files, and search across all plans — with real-time file watching so new plans appear automatically.
+
+<p align="center">
+  <img src="assets/showcase/20-plans.png" alt="Plans" width="720" />
+</p>
+
+---
+
+## Debug Log Viewer
+Diagnose MCP server issues, permission failures, and startup problems with the per-session debug log viewer. Accessible from the session toolbar, it parses `~/.claude/debug/<sessionId>.txt` files with color-coded log levels (DEBUG in gray, WARN in amber, ERROR in red), full-text search, level filtering, and auto-scroll to the first error. Logs are lazily loaded with paginated fetching for smooth performance on large files. Toggle between absolute and relative timestamps, and copy the full log for sharing in bug reports. Searchable via the universal search overlay.
+
+<p align="center">
+  <img src="assets/showcase/21-debug-log.png" alt="Debug Log Viewer" width="720" />
+</p>
+
+---
+
+## Prompt History
+Browse your entire Claude Code input history from `~/.claude/history.jsonl`. Prompts are grouped by date (Today, Yesterday, This Week, etc.), filterable by project, and searchable with full-text fuzzy matching. Copy any prompt to clipboard for reuse. Live file watching keeps the view up to date.
+
+<p align="center">
+  <img src="assets/showcase/21-history.png" alt="Prompt History" width="720" />
+</p>
+
+---
+
+## AI Session Summaries
+See AI-generated session analysis at the top of each session detail. A collapsible card shows the brief summary, underlying goal, outcome badge, helpfulness rating, session type, goal categories as tags, and friction indicators — all parsed from `~/.claude/usage-data/facets/`. Facets are also searchable via the universal search overlay.
+
+<p align="center">
+  <img src="assets/showcase/22-ai-summaries.png" alt="AI Session Summaries" width="720" />
+</p>
+
+---
+
+## Memory
+Browse Claude Code's auto-memory files per project. MEMORY.md is the main entrypoint loaded into every conversation, and topic files contain detailed notes organized by subject. Filter by project, view rendered markdown, and search across all memories with live file watching.
+
+<p align="center">
+  <img src="assets/showcase/23-memory.png" alt="Memory" width="720" />
+</p>


### PR DESCRIPTION
## Summary
- Moved 20 feature screenshots from README into a new `SHOWCASE.md` file
- README now keeps only 3 images (hero, analytics, conversation view) plus a concise bullet list of all features
- Removed duplicate YouTube video embed from README footer
- Added link to showcase: "See all features with screenshots in the Feature Showcase"

## Test plan
- [ ] Verify README renders correctly on GitHub with the 3 remaining images
- [ ] Verify SHOWCASE.md renders correctly with all 20 feature screenshots
- [ ] Verify the "Feature Showcase" link in README points to SHOWCASE.md correctly

Generated with [Claude Code](https://claude.com/claude-code)