### PR TITLE
Usage limits: background auto-refresh, selectable cadence, and 429 handling

### DIFF
--- a/Poirot.xcodeproj/project.pbxproj
+++ b/Poirot.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		3DE55E7904C8DD17F9616516 /* TodoLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206C5507435CF92778FB1288 /* TodoLoaderTests.swift */; };
 		3ECBB12E9DDAA024790F0E9D /* ThinkingBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3AC4EEED07D87A20BA1D6A /* ThinkingBlockView.swift */; };
 		3FD6C509342CC573A40602DC /* ScreenshotTests_ThinkingBlocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4096CDCB301151507A5ADB98 /* ScreenshotTests_ThinkingBlocks.swift */; };
+		41938C1E0A5C8CD008A2D5BE /* UsageRefreshIntervalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3027C1BCAAB40AF5E2FB1F6F /* UsageRefreshIntervalTests.swift */; };
 		419F4F71726C23CCCDA684E0 /* SessionLoadingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4544414C3D790877324A3435 /* SessionLoadingMock.swift */; };
 		41A9030990B46C305BC71358 /* HistoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF81009E16BB4F57D3644958 /* HistoryListView.swift */; };
 		44CD887D9A3F56337F9BF249 /* UsageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EE935BCF596295614CEEE6 /* UsageStore.swift */; };
@@ -140,6 +141,7 @@
 		8D8C83B2FFDFD29781D82613 /* SessionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448BC381E8C88EC3C0F0FE38 /* SessionGroup.swift */; };
 		8F90904E938E5E931C3F8726 /* ClaudeCredentialsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9818FA0A1812D1C79532263A /* ClaudeCredentialsTests.swift */; };
 		8FD7EBED4D0DDE3CE9631847 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 5BE7BB9DDB8F26B3780EDE11 /* Localizable.xcstrings */; };
+		8FE26FE96048A347C79A62A0 /* UsageRefreshInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933C3FDC96E3D8CAB42FA2AA /* UsageRefreshInterval.swift */; };
 		9201DB41BA7A874D25821850 /* PointingHandCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8648DEC1BFD4DFE7E36B0F /* PointingHandCursor.swift */; };
 		95419B1D00A6A145593BB8D3 /* NavigationItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479E51FA034ADB8484234047 /* NavigationItem.swift */; };
 		969DCD717645BA6190A79A04 /* SystemContentParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D242E590A67BD95B835C3377 /* SystemContentParserTests.swift */; };
@@ -302,6 +304,7 @@
 		2DD7203015405A5BB4546AD7 /* ProviderDescribing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderDescribing.swift; sourceTree = "<group>"; };
 		2E27598FA5317EBA2F3566DD /* StatCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatCard.swift; sourceTree = "<group>"; };
 		2ED8108B09E1C0D619F8D98C /* PreferredTerminal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferredTerminal.swift; sourceTree = "<group>"; };
+		3027C1BCAAB40AF5E2FB1F6F /* UsageRefreshIntervalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageRefreshIntervalTests.swift; sourceTree = "<group>"; };
 		32AFC13983EBE2608C7EAF8B /* ScreenshotTests_FileHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTests_FileHistory.swift; sourceTree = "<group>"; };
 		3498814047BCC0D3779C7559 /* SessionLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLoaderTests.swift; sourceTree = "<group>"; };
 		35B31FDA865C64004095C39C /* UpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCheckerTests.swift; sourceTree = "<group>"; };
@@ -382,6 +385,7 @@
 		90EBD21BFE033B77863FE24B /* EditDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditDiffView.swift; sourceTree = "<group>"; };
 		924D1F914ACBAAC3056FE513 /* ScreenshotTests_DebugLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTests_DebugLog.swift; sourceTree = "<group>"; };
 		9262E53B67ADBFE31308E136 /* FileHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHistoryView.swift; sourceTree = "<group>"; };
+		933C3FDC96E3D8CAB42FA2AA /* UsageRefreshInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageRefreshInterval.swift; sourceTree = "<group>"; };
 		93B82B11ED3424132D79393B /* ExportOptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportOptionsView.swift; sourceTree = "<group>"; };
 		9580FE03B8FA1152D430F840 /* MenuBarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarState.swift; sourceTree = "<group>"; };
 		95C0662F587D8C25472925D5 /* ScreenshotTests_Standalone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTests_Standalone.swift; sourceTree = "<group>"; };
@@ -636,6 +640,7 @@
 			children = (
 				2D324CA26A994C09E27E8CD0 /* ClaudeCredentials.swift */,
 				2148750AC945AA6D562F4E05 /* ClaudeUsage.swift */,
+				933C3FDC96E3D8CAB42FA2AA /* UsageRefreshInterval.swift */,
 			);
 			path = Usage;
 			sourceTree = "<group>";
@@ -787,6 +792,7 @@
 				8B3377B2C68680A32D48942B /* StatsCacheTests.swift */,
 				CDF13E0AEC4F26040C330612 /* SubAgentTests.swift */,
 				50BFC6DB8AA0EE305CEAC146 /* TokenUsageTests.swift */,
+				3027C1BCAAB40AF5E2FB1F6F /* UsageRefreshIntervalTests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1375,6 +1381,7 @@
 				013412F73B305C825A289398 /* UpdateChecker.swift in Sources */,
 				53F2AFA6D25E9DDE6D3B96D7 /* UsageGaugeCard.swift in Sources */,
 				F7BF05BCAA0E4E81C8C3EBA9 /* UsageLoading.swift in Sources */,
+				8FE26FE96048A347C79A62A0 /* UsageRefreshInterval.swift in Sources */,
 				44CD887D9A3F56337F9BF249 /* UsageStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1458,6 +1465,7 @@
 				38FE23CA491120BA0341278A /* TranscriptParserTests.swift in Sources */,
 				4772D408F02DE9D706FCE2B4 /* UpdateCheckerTests.swift in Sources */,
 				B1BC2C40E17D1219D47FF2E7 /* UsageLoadingMock.swift in Sources */,
+				41938C1E0A5C8CD008A2D5BE /* UsageRefreshIntervalTests.swift in Sources */,
 				7C742757E9E9BCBC0F46AFCC /* UsageStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Poirot/Sources/App/PoirotApp.swift
+++ b/Poirot/Sources/App/PoirotApp.swift
@@ -110,6 +110,7 @@ struct PoirotApp: App {
         Settings {
             SettingsView()
                 .environment(appState)
+                .environment(usageStore)
         }
 
         MenuBarExtra("Poirot", image: "MenuBarIcon", isInserted: $showMenuBarIcon) {

--- a/Poirot/Sources/App/SettingsView.swift
+++ b/Poirot/Sources/App/SettingsView.swift
@@ -19,12 +19,70 @@ struct SettingsView: View {
                     Label("Viewer", systemImage: "eye")
                 }
 
+            UsageSettingsView()
+                .tabItem {
+                    Label("Usage", systemImage: "gauge.with.dots.needle.bottom.50percent")
+                }
+
             MenuBarSettingsView()
                 .tabItem {
                     Label("Menu Bar", systemImage: "menubar.rectangle")
                 }
         }
         .frame(width: 560, height: 360)
+    }
+}
+
+// MARK: - Usage
+
+private struct UsageSettingsView: View {
+    @Environment(UsageStore.self)
+    private var usageStore
+    @Environment(\.provider)
+    private var provider
+
+    private var intervalBinding: Binding<UsageRefreshInterval> {
+        Binding(
+            get: { usageStore.refreshInterval },
+            set: { usageStore.setRefreshInterval($0) }
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if provider.supports(.usage) {
+                settingsRow {
+                    Text("Auto-Refresh:")
+                } control: {
+                    Picker("", selection: intervalBinding) {
+                        ForEach(UsageRefreshInterval.allCases) { option in
+                            Text(option.label).tag(option)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 200)
+                }
+
+                settingsRow {
+                    Text("")
+                } control: {
+                    Text(usageStore.refreshInterval == .manual
+                        ? "Usage updates only when you tap refresh."
+                        : "Poirot re-fetches your usage \(usageStore.refreshInterval.label.lowercased()) while it's open.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            } else {
+                Text("Usage limits aren't available for this provider.")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, 20)
+        .padding(.horizontal, 32)
     }
 }
 

--- a/Poirot/Sources/App/UsageStore.swift
+++ b/Poirot/Sources/App/UsageStore.swift
@@ -26,6 +26,7 @@ final class UsageStore {
     }
 
     static let enabledKey = "usageLimitsEnabled"
+    static let intervalKey = "usageRefreshIntervalMinutes"
     private static let snapshotKey = "usageSnapshot"
     private static let snapshotDateKey = "usageSnapshotDate"
 
@@ -33,27 +34,36 @@ final class UsageStore {
     private(set) var lastUpdated: Date?
     /// Whether the user has opted in. Off by default — nothing is read or fetched until on.
     private(set) var isEnabled: Bool
+    /// User-chosen background cadence. `.manual` means the poll is off and the user reloads
+    /// on demand. Persisted; change it through `setRefreshInterval(_:)`.
+    private(set) var refreshInterval: UsageRefreshInterval
 
     private let loader: any UsageLoading
     private let defaults: UserDefaults
     /// Minimum spacing between non-forced refreshes, so repeated explicit taps don't hammer.
     private let throttle: TimeInterval
-    /// How often to silently re-fetch once opted in and loaded. `nil` disables the timer
-    /// entirely (previews and unit tests).
-    private let autoRefreshInterval: TimeInterval?
+    /// Test hook: when set, forces the poll interval for non-manual cadences (so timer behavior
+    /// is testable in well under a minute). `nil` in production, where `refreshInterval` rules.
+    private let autoRefreshOverride: TimeInterval?
+    /// Master switch for the background poll — off in previews and snapshot tests.
+    private let autoRefreshEnabled: Bool
     private var autoRefreshTask: Task<Void, Never>?
 
     init(
         loader: any UsageLoading = ClaudeUsageLoader(),
         throttle: TimeInterval = 30,
-        autoRefreshInterval: TimeInterval? = 60,
+        autoRefreshOverride: TimeInterval? = nil,
+        autoRefreshEnabled: Bool = true,
         defaults: UserDefaults = .standard
     ) {
         self.loader = loader
         self.throttle = throttle
-        self.autoRefreshInterval = autoRefreshInterval
+        self.autoRefreshOverride = autoRefreshOverride
+        self.autoRefreshEnabled = autoRefreshEnabled
         self.defaults = defaults
         self.isEnabled = defaults.bool(forKey: Self.enabledKey)
+        let storedMinutes = defaults.object(forKey: Self.intervalKey) as? Int
+        self.refreshInterval = storedMinutes.flatMap(UsageRefreshInterval.init(rawValue:)) ?? .default
         // Restore the last snapshot so a relaunch shows gauges WITHOUT reading the Keychain.
         if isEnabled, let snapshot = Self.loadSnapshot(from: defaults) {
             state = .loaded(snapshot.usage)
@@ -68,13 +78,20 @@ final class UsageStore {
     static func preview(_ state: State, enabled: Bool = true) -> UsageStore {
         let store = UsageStore(
             throttle: .greatestFiniteMagnitude,
-            autoRefreshInterval: nil,
+            autoRefreshEnabled: false,
             defaults: UserDefaults(suiteName: "fyi.poirot.preview") ?? .standard
         )
         store.isEnabled = enabled
         store.state = state
         store.lastUpdated = Date()
         return store
+    }
+
+    /// Effective poll interval in seconds, or `nil` when polling is off (disabled master switch
+    /// or `.manual`). The test override only speeds up non-manual cadences.
+    private var autoRefreshSeconds: TimeInterval? {
+        guard autoRefreshEnabled, refreshInterval != .manual else { return nil }
+        return autoRefreshOverride ?? refreshInterval.seconds
     }
 
     /// The most recently loaded usage, if any (survives across in-flight refreshes).
@@ -101,12 +118,22 @@ final class UsageStore {
 
     // MARK: - Background auto-refresh
 
-    /// Start silently polling for fresh usage. Idempotent, and a no-op when disabled or when the
-    /// timer is turned off (`autoRefreshInterval == nil`). Ticks only re-fetch while `.loaded`, so
-    /// the timer never triggers a Keychain read out of an idle state.
+    /// Change the background cadence (or turn it off with `.manual`). Persists the choice and
+    /// reconfigures the running poll so it takes effect immediately.
+    func setRefreshInterval(_ interval: UsageRefreshInterval) {
+        guard interval != refreshInterval else { return }
+        refreshInterval = interval
+        defaults.set(interval.rawValue, forKey: Self.intervalKey)
+        stopAutoRefresh()
+        startAutoRefresh() // no-op for `.manual`, otherwise restarts at the new cadence
+    }
+
+    /// Start silently polling for fresh usage. Idempotent, and a no-op when disabled, in manual
+    /// mode, or with polling turned off. Ticks only re-fetch while `.loaded`, so the timer never
+    /// triggers a Keychain read out of an idle state.
     func startAutoRefresh() {
         guard isEnabled, autoRefreshTask == nil,
-              let interval = autoRefreshInterval, interval > 0
+              let interval = autoRefreshSeconds, interval > 0
         else { return }
 
         autoRefreshTask = Task { [weak self] in

--- a/Poirot/Sources/App/UsageStore.swift
+++ b/Poirot/Sources/App/UsageStore.swift
@@ -9,6 +9,12 @@ import Observation
 /// is persisted (just utilization + reset times, all local), so on relaunch the gauges show
 /// from cache without touching the Keychain. Any access failure drops back to the idle "Load"
 /// state.
+///
+/// Once opted in **and** already holding loaded data, a background timer silently re-fetches on
+/// `autoRefreshInterval` so the gauges and reset countdowns stay current (a window that already
+/// reset stops lingering). The first tick fires one interval *after* the store starts — never
+/// synchronously on launch/appear — and a tick only ever fires while the state is `.loaded`, so
+/// the "no Keychain read out of nowhere" contract holds: the first read is always explicit.
 @MainActor
 @Observable
 final class UsageStore {
@@ -32,14 +38,20 @@ final class UsageStore {
     private let defaults: UserDefaults
     /// Minimum spacing between non-forced refreshes, so repeated explicit taps don't hammer.
     private let throttle: TimeInterval
+    /// How often to silently re-fetch once opted in and loaded. `nil` disables the timer
+    /// entirely (previews and unit tests).
+    private let autoRefreshInterval: TimeInterval?
+    private var autoRefreshTask: Task<Void, Never>?
 
     init(
         loader: any UsageLoading = ClaudeUsageLoader(),
         throttle: TimeInterval = 30,
+        autoRefreshInterval: TimeInterval? = 60,
         defaults: UserDefaults = .standard
     ) {
         self.loader = loader
         self.throttle = throttle
+        self.autoRefreshInterval = autoRefreshInterval
         self.defaults = defaults
         self.isEnabled = defaults.bool(forKey: Self.enabledKey)
         // Restore the last snapshot so a relaunch shows gauges WITHOUT reading the Keychain.
@@ -47,12 +59,16 @@ final class UsageStore {
             state = .loaded(snapshot.usage)
             lastUpdated = snapshot.date
         }
+        // Begin polling if already opted in. The first tick is a full interval away and only
+        // fires while `.loaded`, so launch itself never reads the Keychain.
+        if isEnabled { startAutoRefresh() }
     }
 
     /// A store pinned to a fixed state for previews and snapshot tests. Never fetches.
     static func preview(_ state: State, enabled: Bool = true) -> UsageStore {
         let store = UsageStore(
             throttle: .greatestFiniteMagnitude,
+            autoRefreshInterval: nil,
             defaults: UserDefaults(suiteName: "fyi.poirot.preview") ?? .standard
         )
         store.isEnabled = enabled
@@ -67,18 +83,47 @@ final class UsageStore {
         return nil
     }
 
-    /// Opt in and immediately fetch (the explicit first read).
+    /// Opt in and immediately fetch (the explicit first read), then keep it fresh in the background.
     func enable() async {
         setEnabled(true)
         await refresh(force: true)
+        startAutoRefresh()
     }
 
     /// Opt back out: stop fetching and forget the cached snapshot.
     func disable() {
         setEnabled(false)
+        stopAutoRefresh()
         clearSnapshot()
         lastUpdated = nil
         state = .idle(note: nil)
+    }
+
+    // MARK: - Background auto-refresh
+
+    /// Start silently polling for fresh usage. Idempotent, and a no-op when disabled or when the
+    /// timer is turned off (`autoRefreshInterval == nil`). Ticks only re-fetch while `.loaded`, so
+    /// the timer never triggers a Keychain read out of an idle state.
+    func startAutoRefresh() {
+        guard isEnabled, autoRefreshTask == nil,
+              let interval = autoRefreshInterval, interval > 0
+        else { return }
+
+        autoRefreshTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(interval))
+                guard let self, !Task.isCancelled else { return }
+                if case .loaded = self.state {
+                    await self.refresh()
+                }
+            }
+        }
+    }
+
+    /// Stop background polling. Called on opt-out; explicit loads restart it.
+    func stopAutoRefresh() {
+        autoRefreshTask?.cancel()
+        autoRefreshTask = nil
     }
 
     private func setEnabled(_ value: Bool) {
@@ -87,9 +132,9 @@ final class UsageStore {
         defaults.set(value, forKey: Self.enabledKey)
     }
 
-    /// Reads the Keychain and fetches usage. Called only from explicit user actions (Enable /
-    /// Load / Refresh) — never on appear — so navigating never prompts. Skips when a fetch
-    /// happened within `throttle` seconds unless `force`.
+    /// Reads the Keychain and fetches usage. Called from explicit user actions (Enable / Load /
+    /// Refresh) and from the background timer once already `.loaded` — never on appear/launch — so
+    /// navigating never prompts. Skips when a fetch happened within `throttle` seconds unless `force`.
     func refresh(force: Bool = false) async {
         guard isEnabled else { return }
         if case .loading = state { return }
@@ -106,6 +151,8 @@ final class UsageStore {
             state = .loaded(usage)
             lastUpdated = now
             saveSnapshot(usage, date: now)
+            // Any successful load (Load button, Try again, toolbar refresh) keeps the poll alive.
+            startAutoRefresh()
 
         case .unauthenticated:
             // Access problem → forget the snapshot and return to the idle Load state (rule 3).

--- a/Poirot/Sources/App/UsageStore.swift
+++ b/Poirot/Sources/App/UsageStore.swift
@@ -48,6 +48,10 @@ final class UsageStore {
     /// Master switch for the background poll — off in previews and snapshot tests.
     private let autoRefreshEnabled: Bool
     private var autoRefreshTask: Task<Void, Never>?
+    /// When set, skip non-forced refreshes until this instant (rate-limit backoff).
+    private var rateLimitedUntil: Date?
+    /// Fallback backoff when the 429 response carries no `Retry-After`.
+    private static let defaultRateLimitBackoff: TimeInterval = 300
 
     init(
         loader: any UsageLoading = ClaudeUsageLoader(),
@@ -113,6 +117,7 @@ final class UsageStore {
         stopAutoRefresh()
         clearSnapshot()
         lastUpdated = nil
+        rateLimitedUntil = nil
         state = .idle(note: nil)
     }
 
@@ -168,6 +173,11 @@ final class UsageStore {
         if !force, let lastUpdated, Date().timeIntervalSince(lastUpdated) < throttle {
             return
         }
+        // The usage endpoint rate-limits how often it can be queried. After a 429 we hold off
+        // (honoring Retry-After) so the poll doesn't keep hammering; an explicit tap still tries.
+        if !force, let rateLimitedUntil, Date() < rateLimitedUntil {
+            return
+        }
 
         let hadData = usage != nil
         if !hadData { state = .loading }
@@ -175,6 +185,7 @@ final class UsageStore {
         switch await loader.loadUsage() {
         case let .success(usage):
             let now = Date()
+            rateLimitedUntil = nil
             state = .loaded(usage)
             lastUpdated = now
             saveSnapshot(usage, date: now)
@@ -186,6 +197,13 @@ final class UsageStore {
             clearSnapshot()
             lastUpdated = nil
             state = .idle(note: "Couldn't read your Claude Code token — allow Keychain access, then load again.")
+
+        case let .rateLimited(retryAfter):
+            // Back off before the next poll; keep any cached gauges rather than dropping them.
+            rateLimitedUntil = Date().addingTimeInterval(retryAfter ?? Self.defaultRateLimitBackoff)
+            if !hadData {
+                state = .idle(note: "Anthropic is limiting usage checks right now — try again in a few minutes.")
+            }
 
         case .failure:
             // Transient (e.g. network): keep any cached gauges; otherwise offer Load.

--- a/Poirot/Sources/Models/Usage/UsageRefreshInterval.swift
+++ b/Poirot/Sources/Models/Usage/UsageRefreshInterval.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// How often Poirot silently re-fetches usage once opted in. `manual` disables the background
+/// poll entirely — the user reloads on demand with the refresh button.
+enum UsageRefreshInterval: Int, CaseIterable, Identifiable, Sendable {
+    case manual = 0
+    case oneMinute = 1
+    case twoMinutes = 2
+    case fiveMinutes = 5
+    case tenMinutes = 10
+    case thirtyMinutes = 30
+
+    /// Cadence for a fresh install: frequent enough to feel live, gentle enough not to hammer.
+    static let `default`: UsageRefreshInterval = .fiveMinutes
+
+    var id: Int { rawValue }
+
+    /// Polling interval in seconds, or `nil` for manual (no background poll).
+    var seconds: TimeInterval? {
+        self == .manual ? nil : TimeInterval(rawValue) * 60
+    }
+
+    /// Full label for pickers and menus.
+    var label: String {
+        switch self {
+        case .manual: "Manual"
+        case .oneMinute: "Every minute"
+        case .twoMinutes: "Every 2 minutes"
+        case .fiveMinutes: "Every 5 minutes"
+        case .tenMinutes: "Every 10 minutes"
+        case .thirtyMinutes: "Every 30 minutes"
+        }
+    }
+
+    /// Compact label for tight spots like the menu bar ("Manual", "5m").
+    var shortLabel: String {
+        self == .manual ? "Manual" : "\(rawValue)m"
+    }
+}

--- a/Poirot/Sources/Models/Usage/UsageRefreshInterval.swift
+++ b/Poirot/Sources/Models/Usage/UsageRefreshInterval.swift
@@ -4,13 +4,13 @@ import Foundation
 /// poll entirely — the user reloads on demand with the refresh button.
 enum UsageRefreshInterval: Int, CaseIterable, Identifiable, Sendable {
     case manual = 0
-    case oneMinute = 1
-    case twoMinutes = 2
     case fiveMinutes = 5
     case tenMinutes = 10
+    case twentyMinutes = 20
     case thirtyMinutes = 30
 
-    /// Cadence for a fresh install: frequent enough to feel live, gentle enough not to hammer.
+    /// Cadence for a fresh install: frequent enough to feel live, gentle enough not to hammer
+    /// the rate-limited usage endpoint.
     static let `default`: UsageRefreshInterval = .fiveMinutes
 
     var id: Int { rawValue }
@@ -24,10 +24,9 @@ enum UsageRefreshInterval: Int, CaseIterable, Identifiable, Sendable {
     var label: String {
         switch self {
         case .manual: "Manual"
-        case .oneMinute: "Every minute"
-        case .twoMinutes: "Every 2 minutes"
         case .fiveMinutes: "Every 5 minutes"
         case .tenMinutes: "Every 10 minutes"
+        case .twentyMinutes: "Every 20 minutes"
         case .thirtyMinutes: "Every 30 minutes"
         }
     }

--- a/Poirot/Sources/Protocols/UsageLoading.swift
+++ b/Poirot/Sources/Protocols/UsageLoading.swift
@@ -6,6 +6,9 @@ nonisolated enum UsageResult: Sendable, Equatable {
     case success(ClaudeUsage)
     /// No credentials found, the token is expired, or the endpoint rejected it (401/403).
     case unauthenticated
+    /// The usage endpoint is rate-limiting us (HTTP 429). Carries the server's `Retry-After`
+    /// in seconds when provided, so the poll can back off instead of hammering.
+    case rateLimited(retryAfter: TimeInterval?)
     /// Network or decoding failure — worth retrying.
     case failure
 }

--- a/Poirot/Sources/Services/ClaudeUsageLoader.swift
+++ b/Poirot/Sources/Services/ClaudeUsageLoader.swift
@@ -38,6 +38,10 @@ nonisolated struct ClaudeUsageLoader: UsageLoading {
         if http.statusCode == 401 || http.statusCode == 403 {
             return .unauthenticated
         }
+        if http.statusCode == 429 {
+            let retryAfter = (http.value(forHTTPHeaderField: "Retry-After")).flatMap(TimeInterval.init)
+            return .rateLimited(retryAfter: retryAfter)
+        }
         guard http.statusCode == 200, let usage = ClaudeUsage.parse(data) else {
             return .failure
         }

--- a/Poirot/Sources/Views/MenuBar/MenuBarView.swift
+++ b/Poirot/Sources/Views/MenuBar/MenuBarView.swift
@@ -48,6 +48,7 @@ struct MenuBarView: View {
     private var usageSection: some View {
         if case let .loaded(usage) = usageStore.state {
             VStack(alignment: .leading, spacing: PoirotTheme.Spacing.xs) {
+                usageHeader
                 MenuBarUsageRow(label: "5h", window: usage.fiveHour)
                 MenuBarUsageRow(label: "7d", window: usage.sevenDay)
             }
@@ -55,6 +56,53 @@ struct MenuBarView: View {
             .padding(.horizontal, PoirotTheme.Spacing.lg)
             .padding(.vertical, PoirotTheme.Spacing.sm)
         }
+    }
+
+    private var usageHeader: some View {
+        HStack(spacing: PoirotTheme.Spacing.xs) {
+            Text("Usage")
+                .font(PoirotTheme.Typography.microSemibold)
+                .foregroundStyle(PoirotTheme.Colors.textTertiary)
+
+            Spacer()
+
+            usageCadenceMenu
+
+            Button {
+                Task { await usageStore.refresh(force: true) }
+            } label: {
+                Image(systemName: "arrow.clockwise")
+                    .font(PoirotTheme.Typography.tiny)
+                    .foregroundStyle(PoirotTheme.Colors.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(usageStore.state == .loading)
+            .help("Refresh usage now")
+        }
+    }
+
+    private var usageCadenceMenu: some View {
+        Menu {
+            Picker("Auto-refresh", selection: Binding(
+                get: { usageStore.refreshInterval },
+                set: { usageStore.setRefreshInterval($0) }
+            )) {
+                ForEach(UsageRefreshInterval.allCases) { option in
+                    Text(option.label).tag(option)
+                }
+            }
+        } label: {
+            HStack(spacing: 2) {
+                Image(systemName: usageStore.refreshInterval == .manual ? "hand.tap" : "timer")
+                Text(usageStore.refreshInterval.shortLabel)
+            }
+            .font(PoirotTheme.Typography.tiny)
+            .foregroundStyle(PoirotTheme.Colors.textTertiary)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Auto-refresh interval")
     }
 
     // MARK: - Header

--- a/PoirotTests/App/UsageStoreTests.swift
+++ b/PoirotTests/App/UsageStoreTests.swift
@@ -27,6 +27,18 @@ struct UsageStoreTests {
         return false
     }
 
+    /// Polls `condition` until it holds or the ceiling elapses, yielding between checks. Keeps
+    /// timer-based tests robust under heavy parallel load instead of depending on a fixed sleep.
+    private static func waitUntil(
+        timeout: Duration = .seconds(5),
+        _ condition: () -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while !condition(), ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
     // MARK: - Opt-in gating
 
     @Test
@@ -199,5 +211,67 @@ struct UsageStoreTests {
 
         #expect(store.isEnabled)
         #expect(store.usage == Self.sampleUsage)
+    }
+
+    // MARK: - Background auto-refresh
+
+    @Test
+    func autoRefresh_pollsWhileLoaded() async throws {
+        let mock = UsageLoadingMock()
+        mock.loadUsageReturnValue = .success(Self.sampleUsage)
+        let store = UsageStore(
+            loader: mock,
+            throttle: 0,
+            autoRefreshInterval: 0.02,
+            defaults: Self.freshDefaults(enabled: false)
+        )
+
+        await store.enable() // explicit first read (count == 1), then the timer takes over
+
+        // Wait until the background timer fetches again, with a generous ceiling so the test
+        // stays robust under load rather than depending on an exact number of ticks in 0.2s.
+        try await Self.waitUntil { mock.loadUsageCallsCount > 1 }
+
+        #expect(mock.loadUsageCallsCount > 1)
+        store.stopAutoRefresh()
+    }
+
+    @Test
+    func autoRefresh_doesNotPollFromIdle() async throws {
+        // Opted in but never loaded (no snapshot) → the timer runs but must not read from idle.
+        let mock = UsageLoadingMock()
+        mock.loadUsageReturnValue = .success(Self.sampleUsage)
+        let store = UsageStore(
+            loader: mock,
+            throttle: 0,
+            autoRefreshInterval: 0.02,
+            defaults: Self.freshDefaults(enabled: true)
+        )
+
+        #expect(Self.isIdle(store.state))
+        try await Task.sleep(for: .seconds(0.2))
+
+        #expect(mock.loadUsageCallsCount == 0)
+        store.stopAutoRefresh()
+    }
+
+    @Test
+    func disable_stopsAutoRefresh() async throws {
+        let mock = UsageLoadingMock()
+        mock.loadUsageReturnValue = .success(Self.sampleUsage)
+        let store = UsageStore(
+            loader: mock,
+            throttle: 0,
+            autoRefreshInterval: 0.02,
+            defaults: Self.freshDefaults(enabled: false)
+        )
+        await store.enable()
+
+        store.disable()
+        let countAtDisable = mock.loadUsageCallsCount
+        try await Task.sleep(for: .seconds(0.2))
+
+        // No further fetches after opting out.
+        #expect(mock.loadUsageCallsCount == countAtDisable)
     }
 }

--- a/PoirotTests/App/UsageStoreTests.swift
+++ b/PoirotTests/App/UsageStoreTests.swift
@@ -151,6 +151,57 @@ struct UsageStoreTests {
     }
 
     @Test
+    func refresh_rateLimited_backsOffUntilForced() async {
+        let mock = UsageLoadingMock()
+        mock.loadUsageReturnValue = .rateLimited(retryAfter: nil)
+        let store = UsageStore(
+            loader: mock, throttle: 0, autoRefreshEnabled: false, defaults: Self.freshDefaults(enabled: true)
+        )
+
+        await store.refresh(force: true) // hits 429 → arms the backoff
+        #expect(mock.loadUsageCallsCount == 1)
+
+        await store.refresh() // non-forced (like a timer tick) is suppressed during backoff
+        #expect(mock.loadUsageCallsCount == 1)
+
+        await store.refresh(force: true) // an explicit tap still tries
+        #expect(mock.loadUsageCallsCount == 2)
+    }
+
+    @Test
+    func refresh_rateLimitedFromIdle_showsNote() async {
+        let mock = UsageLoadingMock()
+        mock.loadUsageReturnValue = .rateLimited(retryAfter: nil)
+        let store = UsageStore(
+            loader: mock, throttle: 0, autoRefreshEnabled: false, defaults: Self.freshDefaults(enabled: true)
+        )
+
+        await store.refresh(force: true)
+
+        guard case let .idle(note) = store.state else {
+            Issue.record("expected idle after rate limit")
+            return
+        }
+        #expect(note?.contains("limiting") == true)
+    }
+
+    @Test
+    func refresh_rateLimitedAfterLoaded_keepsStaleData() async {
+        let mock = UsageLoadingMock()
+        mock.loadUsageReturnValue = .success(Self.sampleUsage)
+        let store = UsageStore(
+            loader: mock, throttle: 0, autoRefreshEnabled: false, defaults: Self.freshDefaults(enabled: true)
+        )
+        await store.refresh()
+
+        mock.loadUsageReturnValue = .rateLimited(retryAfter: nil)
+        await store.refresh(force: true)
+
+        // Rate limiting keeps the cached gauges instead of dropping to an error state.
+        #expect(store.usage == Self.sampleUsage)
+    }
+
+    @Test
     func refresh_networkFailureAfterLoaded_keepsStaleData() async {
         let mock = UsageLoadingMock()
         mock.loadUsageReturnValue = .success(Self.sampleUsage)

--- a/PoirotTests/App/UsageStoreTests.swift
+++ b/PoirotTests/App/UsageStoreTests.swift
@@ -222,7 +222,7 @@ struct UsageStoreTests {
         let store = UsageStore(
             loader: mock,
             throttle: 0,
-            autoRefreshInterval: 0.02,
+            autoRefreshOverride: 0.02,
             defaults: Self.freshDefaults(enabled: false)
         )
 
@@ -244,7 +244,7 @@ struct UsageStoreTests {
         let store = UsageStore(
             loader: mock,
             throttle: 0,
-            autoRefreshInterval: 0.02,
+            autoRefreshOverride: 0.02,
             defaults: Self.freshDefaults(enabled: true)
         )
 
@@ -262,16 +262,57 @@ struct UsageStoreTests {
         let store = UsageStore(
             loader: mock,
             throttle: 0,
-            autoRefreshInterval: 0.02,
+            autoRefreshOverride: 0.02,
             defaults: Self.freshDefaults(enabled: false)
         )
         await store.enable()
 
         store.disable()
+        try await Task.sleep(for: .seconds(0.1)) // let any in-flight tick settle
         let countAtDisable = mock.loadUsageCallsCount
         try await Task.sleep(for: .seconds(0.2))
 
         // No further fetches after opting out.
         #expect(mock.loadUsageCallsCount == countAtDisable)
+    }
+
+    // MARK: - Refresh cadence
+
+    @Test
+    func refreshInterval_defaultsAndPersists() {
+        let defaults = Self.freshDefaults(enabled: false)
+        let store = UsageStore(loader: UsageLoadingMock(), autoRefreshEnabled: false, defaults: defaults)
+
+        #expect(store.refreshInterval == .default)
+
+        store.setRefreshInterval(.tenMinutes)
+        #expect(store.refreshInterval == .tenMinutes)
+        #expect(defaults.integer(forKey: UsageStore.intervalKey) == 10)
+
+        // A relaunch restores the chosen cadence.
+        let restored = UsageStore(loader: UsageLoadingMock(), autoRefreshEnabled: false, defaults: defaults)
+        #expect(restored.refreshInterval == .tenMinutes)
+    }
+
+    @Test
+    func setRefreshInterval_manual_stopsPolling() async throws {
+        let mock = UsageLoadingMock()
+        mock.loadUsageReturnValue = .success(Self.sampleUsage)
+        let store = UsageStore(
+            loader: mock,
+            throttle: 0,
+            autoRefreshOverride: 0.02,
+            defaults: Self.freshDefaults(enabled: false)
+        )
+        await store.enable() // polling on the default (automatic) cadence
+        try await Self.waitUntil { mock.loadUsageCallsCount > 1 }
+
+        store.setRefreshInterval(.manual)
+        try await Task.sleep(for: .seconds(0.1)) // let any in-flight tick settle
+        let settled = mock.loadUsageCallsCount
+        try await Task.sleep(for: .seconds(0.2))
+
+        // Manual mode halts the background poll; the count no longer grows on its own.
+        #expect(mock.loadUsageCallsCount == settled)
     }
 }

--- a/PoirotTests/Models/UsageRefreshIntervalTests.swift
+++ b/PoirotTests/Models/UsageRefreshIntervalTests.swift
@@ -1,0 +1,31 @@
+@testable import Poirot
+import Testing
+
+@Suite("UsageRefreshInterval")
+struct UsageRefreshIntervalTests {
+    @Test
+    func manual_hasNoInterval() {
+        #expect(UsageRefreshInterval.manual.seconds == nil)
+        #expect(UsageRefreshInterval.manual.shortLabel == "Manual")
+    }
+
+    @Test
+    func automatic_mapsMinutesToSeconds() {
+        #expect(UsageRefreshInterval.oneMinute.seconds == 60)
+        #expect(UsageRefreshInterval.fiveMinutes.seconds == 300)
+        #expect(UsageRefreshInterval.thirtyMinutes.seconds == 1800)
+    }
+
+    @Test
+    func shortLabel_isCompactMinutes() {
+        #expect(UsageRefreshInterval.twoMinutes.shortLabel == "2m")
+        #expect(UsageRefreshInterval.tenMinutes.shortLabel == "10m")
+    }
+
+    @Test
+    func rawValueRoundTrips() {
+        for interval in UsageRefreshInterval.allCases {
+            #expect(UsageRefreshInterval(rawValue: interval.rawValue) == interval)
+        }
+    }
+}

--- a/PoirotTests/Models/UsageRefreshIntervalTests.swift
+++ b/PoirotTests/Models/UsageRefreshIntervalTests.swift
@@ -11,15 +11,15 @@ struct UsageRefreshIntervalTests {
 
     @Test
     func automatic_mapsMinutesToSeconds() {
-        #expect(UsageRefreshInterval.oneMinute.seconds == 60)
         #expect(UsageRefreshInterval.fiveMinutes.seconds == 300)
+        #expect(UsageRefreshInterval.twentyMinutes.seconds == 1200)
         #expect(UsageRefreshInterval.thirtyMinutes.seconds == 1800)
     }
 
     @Test
     func shortLabel_isCompactMinutes() {
-        #expect(UsageRefreshInterval.twoMinutes.shortLabel == "2m")
         #expect(UsageRefreshInterval.tenMinutes.shortLabel == "10m")
+        #expect(UsageRefreshInterval.twentyMinutes.shortLabel == "20m")
     }
 
     @Test


### PR DESCRIPTION
## Summary

Follow-up to the usage limits feature (#67). The gauges loaded once and then went
stale — the menu bar could show a 5-hour window as "resets now" long after it had
actually reset, because usage was only ever re-fetched on an explicit action. This
PR keeps usage fresh automatically, lets the user control the cadence, and handles
the usage endpoint's rate limiting gracefully.

## Changes

- **Background auto-refresh.** `UsageStore` now silently re-fetches on a timer once
  opted in and already loaded. The first tick fires one interval *after* the store
  starts (never synchronously on launch/appear), and a tick only fetches while
  `.loaded`, so the first Keychain read is still always explicit — navigating never
  prompts. Opt-out stops the poll; any successful load (re)starts it.
- **User-selectable cadence.** Manual (reload button only) or automatic every
  **5 / 10 / 20 / 30 minutes** (default 5m). New `UsageRefreshInterval` model,
  persisted in `UserDefaults`, applied live via `setRefreshInterval(_:)`.
  - Menu bar usage section gains a compact cadence menu + a manual refresh button.
  - New **Settings → Usage** tab with the full cadence picker.
- **Rate-limit handling (HTTP 429).** The `/oauth/usage` endpoint rate-limits how
  often it can be queried; frequent polling tripped it, and the loader lumped 429
  into `.failure` (surfacing a misleading "Couldn't reach Anthropic" message while
  the poll kept hammering). Added `UsageResult.rateLimited(retryAfter:)`: the loader
  maps 429 to it (honoring `Retry-After`), and the store backs off until then
  (default 5m) before the next non-forced refresh while keeping cached gauges. An
  explicit tap still tries immediately.

## Screenshots

Menu bar usage section now has a `Usage` header with a cadence menu (`⏱ 5m` / `Manual`)
and a refresh button above the 5h/7d bars; Settings has a new Usage tab. No dashboard
or component snapshots changed (the usage section and gauge components are untouched).

## Test Plan

- [x] Builds without warnings (`xcodebuild build`)
- [x] All existing tests pass (`xcodebuild test` — 563/563 in the CI-gated set)
- [x] SwiftLint passes with no new violations
- [x] New/changed code has test coverage (auto-refresh polling/idle/disable, cadence
      persistence + manual-stops-poll, 429 backoff/idle-note/keeps-stale-data,
      `UsageRefreshInterval` mapping)
- [x] Tested on macOS 15+ (built and run locally)

## Related Issues

Relates to #38. Follows up #67.
