### PR TITLE
Add hover tooltips across the app

### DIFF
--- a/Poirot/Sources/App/AboutView.swift
+++ b/Poirot/Sources/App/AboutView.swift
@@ -33,6 +33,7 @@ struct AboutView: View {
                         }
                     }
                     .buttonStyle(.link)
+                    .help("Open the project on GitHub")
                     .font(.system(size: 12))
 
                     Text("·")
@@ -51,6 +52,7 @@ struct AboutView: View {
                         }
                     }
                     .buttonStyle(.link)
+                    .help("Sponsor on GitHub")
                     .font(.system(size: 12))
                 }
 
@@ -68,6 +70,7 @@ struct AboutView: View {
                         }
                     }
                     .buttonStyle(.link)
+                    .help("Open Threads profile")
                     .font(.system(size: 10))
 
                     Button("leo@leocardz.com") {
@@ -76,6 +79,7 @@ struct AboutView: View {
                         }
                     }
                     .buttonStyle(.link)
+                    .help("Send an email")
                     .font(.system(size: 10))
                 }
             }

--- a/Poirot/Sources/App/PoirotApp.swift
+++ b/Poirot/Sources/App/PoirotApp.swift
@@ -47,6 +47,7 @@ struct PoirotApp: App {
                 Button("About Poirot") {
                     openWindow(id: "about")
                 }
+                .help("Open the About window")
 
                 Divider()
 
@@ -74,24 +75,30 @@ struct PoirotApp: App {
                         }
                     }
                 }
+                .help("Check for updates")
             }
             CommandGroup(after: .textFormatting) {
                 Button("Increase Font Size") { appState.increaseFontScale() }
                     .keyboardShortcut("+", modifiers: .command)
+                    .help("Increase font size")
                 Button("Decrease Font Size") { appState.decreaseFontScale() }
                     .keyboardShortcut("-", modifiers: .command)
+                    .help("Decrease font size")
                 Button("Reset Font Size") { appState.resetFontScale() }
                     .keyboardShortcut("0", modifiers: .command)
+                    .help("Reset font size")
             }
             CommandGroup(replacing: .help) {
                 Button("Poirot Help") {
                     openWindow(id: "help")
                 }
                 .keyboardShortcut("?", modifiers: .command)
+                .help("Open Poirot Help")
 
                 Button("Keyboard Shortcuts") {
                     appState.isShortcutHelpPresented = true
                 }
+                .help("Show keyboard shortcuts")
             }
         }
 

--- a/Poirot/Sources/App/SettingsView.swift
+++ b/Poirot/Sources/App/SettingsView.swift
@@ -155,6 +155,7 @@ private struct GeneralSettingsView: View {
                     Button("Browse\u{2026}") {
                         browseForCLI()
                     }
+                    .help("Browse for the CLI executable")
                 }
             }
             Spacer()
@@ -265,13 +266,16 @@ private struct AppearanceSettingsView: View {
                     Button { appState.decreaseFontScale() } label: {
                         Image(systemName: "minus")
                     }
+                    .help("Decrease font size")
                     Text("\(Int(round(appState.fontScale * 100)))%")
                         .monospacedDigit()
                         .frame(width: 44, alignment: .center)
                     Button { appState.increaseFontScale() } label: {
                         Image(systemName: "plus")
                     }
+                    .help("Increase font size")
                     Button("Reset") { appState.resetFontScale() }
+                        .help("Reset font size to 100%")
                         .disabled(appState.fontScale == 1.0)
                 }
             }

--- a/Poirot/Sources/Views/Analytics/AnalyticsDashboardView.swift
+++ b/Poirot/Sources/Views/Analytics/AnalyticsDashboardView.swift
@@ -126,6 +126,7 @@ struct AnalyticsDashboardView: View {
                     viewModel.isCustomRangePresented = false
                 }
                 .buttonStyle(.plain)
+                .help("Cancel")
                 .foregroundStyle(PoirotTheme.Colors.textSecondary)
 
                 Spacer()
@@ -134,6 +135,7 @@ struct AnalyticsDashboardView: View {
                     viewModel.applyCustomRange()
                 }
                 .buttonStyle(.borderedProminent)
+                .help("Apply custom range")
                 .tint(PoirotTheme.Colors.accent)
             }
         }
@@ -150,6 +152,7 @@ struct AnalyticsDashboardView: View {
                     } label: {
                         Label("Share as Image", systemImage: "photo")
                     }
+                    .help("Share dashboard as image")
                 }
                 Section("Export CSV") {
                     ForEach(AnalyticsExportType.allCases) { type in
@@ -157,6 +160,7 @@ struct AnalyticsDashboardView: View {
                             let csv = AnalyticsCSVExporter.export(stats, type: type)
                             AnalyticsCSVExporter.presentSavePanel(csv: csv, suggestedName: type.suggestedFileName)
                         }
+                        .help("Export \(type.rawValue) as CSV")
                     }
                 }
             }
@@ -168,6 +172,7 @@ struct AnalyticsDashboardView: View {
         .menuIndicator(.hidden)
         .frame(width: 24)
         .disabled(viewModel.stats == nil)
+        .help("Share or export")
     }
 
     private func shareAsImage(_ stats: StatsCache) {

--- a/Poirot/Sources/Views/Analytics/Components/StatCard.swift
+++ b/Poirot/Sources/Views/Analytics/Components/StatCard.swift
@@ -73,6 +73,7 @@ private struct InfoTooltipButton: View {
                 .foregroundStyle(PoirotTheme.Colors.textTertiary)
         }
         .buttonStyle(.plain)
+        .help("More info")
         .popover(isPresented: $isPresented, arrowEdge: .top) {
             Text(text)
                 .font(PoirotTheme.Typography.small)

--- a/Poirot/Sources/Views/Analytics/Components/UsageGaugeCard.swift
+++ b/Poirot/Sources/Views/Analytics/Components/UsageGaugeCard.swift
@@ -143,6 +143,7 @@ struct UsagePlaceholderCard: View {
             if let action {
                 Button(action.title, action: action.handler)
                     .buttonStyle(.borderless)
+                    .help(action.title)
                     .font(PoirotTheme.Typography.captionMedium)
                     .foregroundStyle(PoirotTheme.Colors.accent)
             }
@@ -203,6 +204,7 @@ struct UsageOptInCard: View {
                     .font(PoirotTheme.Typography.captionMedium)
             }
             .buttonStyle(.borderedProminent)
+            .help(actionTitle)
             .tint(PoirotTheme.Colors.accent)
 
             UsageDisclaimer()

--- a/Poirot/Sources/Views/Components/SidebarView.swift
+++ b/Poirot/Sources/Views/Components/SidebarView.swift
@@ -78,6 +78,7 @@ struct SidebarView: View {
             isActive: appState.selectedNav == item,
             isKeyboardSelected: isKeyboardSelected
         ))
+        .help(item.title)
     }
 
     private func recomputeSidebarCounts() async {

--- a/Poirot/Sources/Views/Components/ThemePicker.swift
+++ b/Poirot/Sources/Views/Components/ThemePicker.swift
@@ -66,6 +66,7 @@ private struct ThemeOption: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .help(theme.label)
     }
 }
 

--- a/Poirot/Sources/Views/Config/CommandsListView.swift
+++ b/Poirot/Sources/Views/Config/CommandsListView.swift
@@ -349,6 +349,7 @@ private struct CommandCard: View {
             .cardChrome(isHovered: isHovered)
         }
         .buttonStyle(.plain)
+        .help("Open command")
         .onHover { isHovered = $0 }
     }
 }

--- a/Poirot/Sources/Views/Config/ConfigFilterField.swift
+++ b/Poirot/Sources/Views/Config/ConfigFilterField.swift
@@ -25,6 +25,7 @@ struct ConfigFilterField: View {
                         .foregroundStyle(PoirotTheme.Colors.textTertiary)
                 }
                 .buttonStyle(.plain)
+                .help("Clear filter")
             }
         }
         .padding(.horizontal, PoirotTheme.Spacing.md)

--- a/Poirot/Sources/Views/Config/ConfigProjectPicker.swift
+++ b/Poirot/Sources/Views/Config/ConfigProjectPicker.swift
@@ -28,6 +28,7 @@ struct ConfigProjectPicker: View {
                         .foregroundStyle(PoirotTheme.Colors.textTertiary)
                 }
                 .buttonStyle(.plain)
+                .help("Clear project")
             } else {
                 Text("No project selected")
                     .font(PoirotTheme.Typography.caption)
@@ -44,6 +45,7 @@ struct ConfigProjectPicker: View {
                     .foregroundStyle(PoirotTheme.Colors.textSecondary)
             }
             .buttonStyle(.plain)
+            .help("Choose project folder")
         }
         .padding(.horizontal, PoirotTheme.Spacing.md)
         .padding(.vertical, PoirotTheme.Spacing.sm)

--- a/Poirot/Sources/Views/Config/HookFormView.swift
+++ b/Poirot/Sources/Views/Config/HookFormView.swift
@@ -194,12 +194,14 @@ struct HookFormView: View {
         HStack {
             Button("Cancel") { onCancel() }
                 .keyboardShortcut(.cancelAction)
+                .help("Cancel")
 
             Spacer()
 
             Button(isEditing ? "Save" : "Create") { save() }
                 .keyboardShortcut(.defaultAction)
                 .disabled(!isValid)
+                .help(isEditing ? "Save hook" : "Create hook")
         }
         .padding(.horizontal, PoirotTheme.Spacing.xl)
         .padding(.vertical, PoirotTheme.Spacing.md)

--- a/Poirot/Sources/Views/Config/HooksListView.swift
+++ b/Poirot/Sources/Views/Config/HooksListView.swift
@@ -387,6 +387,7 @@ private struct HookCard: View {
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
+        .help("Hook actions")
         .frame(width: 20)
     }
 }

--- a/Poirot/Sources/Views/Config/MCPServersListView.swift
+++ b/Poirot/Sources/Views/Config/MCPServersListView.swift
@@ -418,6 +418,7 @@ private struct MCPServerCard: View {
                                 .foregroundStyle(PoirotTheme.Colors.accent)
                         }
                         .buttonStyle(.plain)
+                        .help(isExpanded ? "Show fewer tools" : "Show all tools")
                     }
                 }
             }

--- a/Poirot/Sources/Views/Config/MCPSetupWizardView.swift
+++ b/Poirot/Sources/Views/Config/MCPSetupWizardView.swift
@@ -302,6 +302,7 @@ struct MCPSetupWizardView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .help("Configure a custom server")
     }
 
     private func catalogRow(_ entry: MCPCatalogEntry) -> some View {
@@ -358,6 +359,7 @@ struct MCPSetupWizardView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .help("Configure \(entry.name)")
     }
 
     // MARK: - Step 2: Configuration
@@ -584,10 +586,12 @@ struct MCPSetupWizardView: View {
                         step = WizardStep(rawValue: step.rawValue - 1) ?? .selectServer
                     }
                 }
+                .help("Go back")
             }
 
             Button("Cancel") { dismiss() }
                 .keyboardShortcut(.cancelAction)
+                .help("Cancel")
 
             Spacer()
 
@@ -602,11 +606,13 @@ struct MCPSetupWizardView: View {
                 }
                 .keyboardShortcut(.defaultAction)
                 .disabled(!isConfigValid)
+                .help("Preview configuration")
             case .preview:
                 Button(isEditing ? "Save" : "Add Server") {
                     saveServer()
                 }
                 .keyboardShortcut(.defaultAction)
+                .help(isEditing ? "Save server" : "Add server")
             }
         }
         .padding(.horizontal, PoirotTheme.Spacing.xl)

--- a/Poirot/Sources/Views/Config/ModelsListView.swift
+++ b/Poirot/Sources/Views/Config/ModelsListView.swift
@@ -337,6 +337,7 @@ private struct ModelCard: View {
                             .foregroundStyle(PoirotTheme.Colors.accent)
                         }
                         .buttonStyle(.plain)
+                        .help("Set as global default")
                     }
 
                     if hasProject, !isProjectDefault {
@@ -352,6 +353,7 @@ private struct ModelCard: View {
                             .foregroundStyle(PoirotTheme.Colors.green)
                         }
                         .buttonStyle(.plain)
+                        .help("Set as project default")
                     }
 
                     if isProjectDefault {
@@ -367,6 +369,7 @@ private struct ModelCard: View {
                             .foregroundStyle(PoirotTheme.Colors.red)
                         }
                         .buttonStyle(.plain)
+                        .help("Clear project override")
                     }
                 }
             }

--- a/Poirot/Sources/Views/Config/OutputStylesListView.swift
+++ b/Poirot/Sources/Views/Config/OutputStylesListView.swift
@@ -291,6 +291,7 @@ private struct OutputStyleCard: View {
             .cardChrome(isHovered: isHovered)
         }
         .buttonStyle(.plain)
+        .help("Open output style")
         .onHover { isHovered = $0 }
     }
 }

--- a/Poirot/Sources/Views/Config/PluginsListView.swift
+++ b/Poirot/Sources/Views/Config/PluginsListView.swift
@@ -258,6 +258,7 @@ private struct PluginCard: View {
                     )
                 }
                 .buttonStyle(.plain)
+                .help(plugin.isEnabled ? "Disable plugin" : "Enable plugin")
                 .popover(isPresented: $showTogglePopover) {
                     Button {
                         showTogglePopover = false

--- a/Poirot/Sources/Views/Config/SkillsListView.swift
+++ b/Poirot/Sources/Views/Config/SkillsListView.swift
@@ -324,6 +324,7 @@ private struct SkillCard: View {
             .cardChrome(isHovered: isHovered)
         }
         .buttonStyle(.plain)
+        .help("Open skill")
         .onHover { isHovered = $0 }
     }
 }

--- a/Poirot/Sources/Views/Config/SubAgentFormView.swift
+++ b/Poirot/Sources/Views/Config/SubAgentFormView.swift
@@ -79,9 +79,11 @@ struct SubAgentFormView: View {
                 Spacer()
                 Button("Cancel") { dismiss() }
                     .keyboardShortcut(.cancelAction)
+                    .help("Cancel")
                 Button(isEditing ? "Save" : "Create") { save() }
                     .keyboardShortcut(.defaultAction)
                     .disabled(!isValid)
+                    .help(isEditing ? "Save agent" : "Create agent")
             }
             .padding(PoirotTheme.Spacing.lg)
         }

--- a/Poirot/Sources/Views/Help/HelpView.swift
+++ b/Poirot/Sources/Views/Help/HelpView.swift
@@ -56,6 +56,7 @@ struct HelpView: View {
                         .font(PoirotTheme.Typography.caption)
                 }
                 .buttonStyle(.plain)
+                .help("Show all keyboard shortcuts")
                 .foregroundStyle(PoirotTheme.Colors.accent)
             }
 

--- a/Poirot/Sources/Views/Help/ShortcutHelpView.swift
+++ b/Poirot/Sources/Views/Help/ShortcutHelpView.swift
@@ -45,6 +45,7 @@ struct ShortcutHelpView: View {
                     .foregroundStyle(PoirotTheme.Colors.textTertiary)
             }
             .buttonStyle(.plain)
+            .help("Close")
         }
         .padding(PoirotTheme.Spacing.xl)
     }

--- a/Poirot/Sources/Views/History/HistoryListView.swift
+++ b/Poirot/Sources/Views/History/HistoryListView.swift
@@ -620,5 +620,6 @@ private struct HistoryToolbarContent: ToolbarContent {
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
+        .help("Filter by project")
     }
 }

--- a/Poirot/Sources/Views/Memory/MemoryListView.swift
+++ b/Poirot/Sources/Views/Memory/MemoryListView.swift
@@ -391,6 +391,7 @@ private struct ProjectChip: View {
             )
         }
         .buttonStyle(.plain)
+        .help("Filter by \(name)")
         .onHover { isHovered = $0 }
     }
 }
@@ -498,6 +499,7 @@ private struct MemoryCard: View {
             .cardChrome(isHovered: isHovered)
         }
         .buttonStyle(.plain)
+        .help("Open memory file")
         .onHover { isHovered = $0 }
     }
 }

--- a/Poirot/Sources/Views/MenuBar/MenuBarView.swift
+++ b/Poirot/Sources/Views/MenuBar/MenuBarView.swift
@@ -160,6 +160,7 @@ struct MenuBarView: View {
                 .font(PoirotTheme.Typography.tiny)
                 .foregroundStyle(PoirotTheme.Colors.textTertiary)
         }
+        .help("Total \(label)")
     }
 
     // MARK: - Search
@@ -190,6 +191,7 @@ struct MenuBarView: View {
                         .foregroundStyle(PoirotTheme.Colors.textTertiary)
                 }
                 .buttonStyle(.plain)
+                .help("Clear search")
             }
         }
         .padding(.horizontal, PoirotTheme.Spacing.lg)
@@ -256,6 +258,7 @@ struct MenuBarView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .help("Open the main window")
         .foregroundStyle(PoirotTheme.Colors.textPrimary)
     }
 
@@ -359,6 +362,7 @@ private struct MenuBarSessionRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .help(session.title)
         .onHover { isHovered = $0 }
     }
 }

--- a/Poirot/Sources/Views/Onboarding/OnboardingView.swift
+++ b/Poirot/Sources/Views/Onboarding/OnboardingView.swift
@@ -202,6 +202,7 @@ struct OnboardingView: View {
                         .foregroundStyle(PoirotTheme.Colors.textSecondary)
                 }
                 .buttonStyle(.plain)
+                .help("Go back")
                 .opacity(currentPage > 0 ? 1 : 0)
                 .disabled(currentPage == 0)
 
@@ -212,6 +213,7 @@ struct OnboardingView: View {
                         withAnimation { currentPage += 1 }
                     }
                     .buttonStyle(.borderedProminent)
+                    .help("Go to the next step")
                     .tint(PoirotTheme.Colors.accent)
                     .controlSize(.large)
                 } else {
@@ -219,6 +221,7 @@ struct OnboardingView: View {
                         dismiss()
                     }
                     .buttonStyle(.borderedProminent)
+                    .help("Get started with Poirot")
                     .tint(PoirotTheme.Colors.accent)
                     .controlSize(.large)
                 }

--- a/Poirot/Sources/Views/Plans/PlansListView.swift
+++ b/Poirot/Sources/Views/Plans/PlansListView.swift
@@ -309,6 +309,7 @@ private struct PlanCard: View {
             .cardChrome(isHovered: isHovered)
         }
         .buttonStyle(.plain)
+        .help("Open plan")
         .onHover { isHovered = $0 }
         .confirmationDialog(
             "Delete \(plan.name)?",

--- a/Poirot/Sources/Views/Project/ProjectSessionsView.swift
+++ b/Poirot/Sources/Views/Project/ProjectSessionsView.swift
@@ -228,6 +228,7 @@ private struct SessionCard: View {
             }
         }
         .buttonStyle(.plain)
+        .help("Open session")
         .onHover { isHovered = $0 }
     }
 }
@@ -277,6 +278,7 @@ private struct SessionListRow: View {
             }
         }
         .buttonStyle(.plain)
+        .help("Open session")
         .onHover { isHovered = $0 }
     }
 }

--- a/Poirot/Sources/Views/Session/DebugLogView.swift
+++ b/Poirot/Sources/Views/Session/DebugLogView.swift
@@ -230,6 +230,7 @@ struct DebugLogView: View {
                         )
                 }
                 .buttonStyle(.plain)
+                .help("Clear search")
             }
         }
         .padding(.horizontal, PoirotTheme.Spacing.sm)
@@ -283,6 +284,7 @@ struct DebugLogView: View {
                         )
                 }
                 .buttonStyle(.plain)
+                .help(isActive ? "Hide \(level.label) entries" : "Show \(level.label) entries")
             }
         }
     }

--- a/Poirot/Sources/Views/Session/ExportOptionsView.swift
+++ b/Poirot/Sources/Views/Session/ExportOptionsView.swift
@@ -48,6 +48,7 @@ struct ExportOptionsView: View {
                     copyMarkdown()
                 }
                 .buttonStyle(.bordered)
+                .help("Copy session as Markdown")
 
                 Spacer()
 
@@ -55,6 +56,7 @@ struct ExportOptionsView: View {
                     exportMarkdown()
                 }
                 .buttonStyle(.borderedProminent)
+                .help("Export session as Markdown")
             }
         }
         .padding(PoirotTheme.Spacing.lg)

--- a/Poirot/Sources/Views/Session/FileHistoryView.swift
+++ b/Poirot/Sources/Views/Session/FileHistoryView.swift
@@ -85,6 +85,7 @@ struct FileHistoryView: View {
                     .foregroundStyle(PoirotTheme.Colors.textTertiary)
             }
             .buttonStyle(.plain)
+            .help("Close")
         }
         .padding(.horizontal, PoirotTheme.Spacing.xl)
         .padding(.vertical, PoirotTheme.Spacing.lg)
@@ -156,6 +157,7 @@ struct FileHistoryView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .help(entry.fileName)
     }
 
     // MARK: - Version Detail
@@ -218,6 +220,7 @@ struct FileHistoryView: View {
                         )
                     }
                     .buttonStyle(.plain)
+                    .help("View version \(version.version)")
                 }
             }
             .padding(.horizontal, PoirotTheme.Spacing.lg)

--- a/Poirot/Sources/Views/Session/SessionDetailView.swift
+++ b/Poirot/Sources/Views/Session/SessionDetailView.swift
@@ -230,6 +230,7 @@ struct SessionDetailView: View {
                         )
                     }
                     .buttonStyle(.plain)
+                    .help("Filter by \(provider.toolDisplayName(for: toolName))")
                 }
 
                 if !appState.activeToolFilters.isEmpty {
@@ -241,6 +242,7 @@ struct SessionDetailView: View {
                             .foregroundStyle(PoirotTheme.Colors.textTertiary)
                     }
                     .buttonStyle(.plain)
+                    .help("Clear tool filters")
                 }
             }
             .padding(.horizontal, PoirotTheme.Spacing.lg)
@@ -344,6 +346,7 @@ struct SessionDetailView: View {
                             }
                         }
                         .buttonStyle(.plain)
+                        .help(isLoadingMore ? "Loading more messages" : "Scroll to bottom")
                         .padding(.bottom, PoirotTheme.Spacing.md)
                         .transition(.opacity.combined(with: .scale(scale: 0.8)))
                     }
@@ -605,6 +608,7 @@ private struct ToolResultBlock: View {
                 .padding(.vertical, PoirotTheme.Spacing.xs)
             }
             .buttonStyle(.plain)
+            .help(isExpanded ? "Collapse tool result" : "Expand tool result")
 
             if isExpanded, !result.content.isEmpty {
                 Divider().opacity(0.3)
@@ -641,6 +645,7 @@ private struct ToolResultBlock: View {
                                 .padding(.vertical, PoirotTheme.Spacing.xs)
                         }
                         .buttonStyle(.plain)
+                        .help(showAllLines ? "Show less" : "Show all \(contentLines.count) lines")
                     }
                 }
                 .background(PoirotTheme.Colors.bgCode)
@@ -935,7 +940,8 @@ private struct BubbleActionButtons: View {
             BubbleIconButton(
                 icon: isFormatted ? "doc.plaintext" : "doc.richtext",
                 isActive: isFormatted,
-                activeColor: PoirotTheme.Colors.accent
+                activeColor: PoirotTheme.Colors.accent,
+                help: isFormatted ? "Show plain text" : "Show formatted"
             ) {
                 isFormatted.toggle()
             }
@@ -962,7 +968,8 @@ private struct BubbleActionButtons: View {
             BubbleIconButton(
                 icon: copied ? "checkmark" : "doc.on.doc",
                 isActive: copied,
-                activeColor: PoirotTheme.Colors.green
+                activeColor: PoirotTheme.Colors.green,
+                help: "Copy text"
             ) {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(text, forType: .string)

--- a/Poirot/Sources/Views/Session/SessionFacetsCard.swift
+++ b/Poirot/Sources/Views/Session/SessionFacetsCard.swift
@@ -63,6 +63,7 @@ struct SessionFacetsCard: View {
             .padding(.vertical, PoirotTheme.Spacing.md)
         }
         .buttonStyle(.plain)
+        .help(isExpanded ? "Collapse AI summary" : "Expand AI summary")
     }
 
     // MARK: - Expanded Content

--- a/Poirot/Sources/Views/Session/SessionTodosView.swift
+++ b/Poirot/Sources/Views/Session/SessionTodosView.swift
@@ -72,6 +72,7 @@ struct SessionTodosView: View {
             .padding(.vertical, PoirotTheme.Spacing.md)
         }
         .buttonStyle(.plain)
+        .help(isExpanded ? "Collapse todos" : "Expand todos")
     }
 
     // MARK: - Status Summary

--- a/Poirot/Sources/Views/Session/SessionToolbarContent.swift
+++ b/Poirot/Sources/Views/Session/SessionToolbarContent.swift
@@ -79,6 +79,7 @@ struct SessionToolbarActions: View {
             )
             .contentTransition(.symbolEffect(.replace))
         }
+        .help("Copy resume command")
         .animation(.easeInOut(duration: 0.2), value: resumeTapped)
 
         Button {

--- a/Poirot/Sources/Views/Session/SessionsNavigationView.swift
+++ b/Poirot/Sources/Views/Session/SessionsNavigationView.swift
@@ -78,7 +78,7 @@ struct SessionsNavigationView: View {
             } else if filteredProjects.isEmpty {
                 emptySearchState
             } else {
-                ScrollViewReader { proxy in
+                ScrollViewReader { _ in
                     ScrollView {
                         LazyVStack(alignment: .leading, spacing: 0) {
                             ForEach(filteredProjects) { project in

--- a/Poirot/Sources/Views/Session/SessionsNavigationView.swift
+++ b/Poirot/Sources/Views/Session/SessionsNavigationView.swift
@@ -172,6 +172,7 @@ struct SessionsNavigationView: View {
                     .foregroundStyle(PoirotTheme.Colors.textTertiary)
             }
             .buttonStyle(.plain)
+            .help("Refresh sessions")
         }
     }
 
@@ -200,6 +201,7 @@ struct SessionsNavigationView: View {
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
         .fixedSize()
+        .help("Sort projects")
     }
 
     private var sessionsListSearchBar: some View {
@@ -222,6 +224,7 @@ struct SessionsNavigationView: View {
                         .foregroundStyle(PoirotTheme.Colors.textTertiary)
                 }
                 .buttonStyle(.plain)
+                .help("Clear search")
             }
         }
         .padding(.horizontal, PoirotTheme.Spacing.sm)
@@ -404,6 +407,7 @@ private struct SessionsProjectSection: View {
                     .frame(width: 12, height: 18)
             }
             .buttonStyle(.plain)
+            .help(isCollapsed ? "Expand project" : "Collapse project")
 
             Button {
                 appState.selectedSession = nil
@@ -434,6 +438,7 @@ private struct SessionsProjectSection: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .help(project.name)
         }
         .padding(.horizontal, PoirotTheme.Spacing.md)
         .padding(.vertical, PoirotTheme.Spacing.sm)
@@ -599,6 +604,7 @@ private struct AgentSessionRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .help(session.title)
         .onHover { isHovered = $0 }
     }
 
@@ -681,6 +687,7 @@ private struct SessionsListRow: View {
                             .contentShape(Capsule())
                         }
                         .buttonStyle(.plain)
+                        .help(isAgentExpanded ? "Hide agent sessions" : "Show agent sessions")
                     }
 
                     Text(session.timeAgo)
@@ -738,6 +745,7 @@ private struct SessionsListRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .help(session.title)
         .onHover { isHovered = $0 }
     }
 

--- a/Poirot/Sources/Views/Session/SystemContentView.swift
+++ b/Poirot/Sources/Views/Session/SystemContentView.swift
@@ -45,6 +45,7 @@ struct SystemContentView: View {
                 )
             }
             .buttonStyle(.plain)
+            .help(isExpanded ? "Collapse system context" : "Expand system context")
             .onAppear {
                 isExpanded = UserDefaults.standard.bool(forKey: "autoExpandBlocks")
             }

--- a/Poirot/Sources/Views/Session/ThinkingBlockView.swift
+++ b/Poirot/Sources/Views/Session/ThinkingBlockView.swift
@@ -73,6 +73,7 @@ struct ThinkingBlockView: View {
                 )
             }
             .buttonStyle(.plain)
+            .help(isExpanded ? "Collapse thinking" : "Expand thinking")
             .onAppear {
                 isExpanded = UserDefaults.standard.bool(forKey: "autoExpandBlocks")
             }
@@ -109,6 +110,7 @@ struct ThinkingBlockView: View {
                                 .padding(.vertical, PoirotTheme.Spacing.xs)
                         }
                         .buttonStyle(.plain)
+                        .help(showAll ? "Show less" : "Show all \(lines.count) lines")
                     }
                 }
                 .background(PoirotTheme.Colors.bgCode)
@@ -185,6 +187,7 @@ struct ThinkingBlockView: View {
                 )
         }
         .buttonStyle(.plain)
+        .help("Copy thinking")
         .animation(.easeInOut(duration: 0.2), value: copied)
     }
 }

--- a/Poirot/Sources/Views/Session/ToolBlockView.swift
+++ b/Poirot/Sources/Views/Session/ToolBlockView.swift
@@ -130,6 +130,7 @@ struct ToolBlockView: View {
                 .background(PoirotTheme.Colors.bgElevated)
             }
             .buttonStyle(.plain)
+            .help(isExpanded ? "Collapse" : "Expand")
 
             if isExpanded {
                 Divider().opacity(0.3)
@@ -175,6 +176,7 @@ struct ToolBlockView: View {
                                     .padding(.vertical, PoirotTheme.Spacing.xs)
                             }
                             .buttonStyle(.plain)
+                            .help(showAllLines ? "Show less" : "Show all \(contentLines.count) lines")
                         }
                     }
                     .background(PoirotTheme.Colors.bgCode)
@@ -334,6 +336,7 @@ struct ToolBlockView: View {
                 )
         }
         .buttonStyle(.plain)
+        .help("Copy content")
         .animation(.easeInOut(duration: 0.2), value: copied)
     }
 

--- a/Poirot/Sources/Views/Todos/TodosOverviewView.swift
+++ b/Poirot/Sources/Views/Todos/TodosOverviewView.swift
@@ -520,6 +520,7 @@ private struct SessionTodoCard: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .help(isExpanded ? "Collapse todos" : "Expand todos")
     }
 
     private var goToSessionButton: some View {


### PR DESCRIPTION
## What

Adds hover tooltips (`.help(...)`) to interactive buttons across the entire app. Previously only a handful of buttons (e.g. "Copy as Markdown") surfaced a tooltip, leaving most icon buttons unexplained on hover.

## Scope

93 tooltips added across 40 files:

- **Conversations** — bubble format-toggle & copy-raw, tool-block copy, thinking-block copy, expand/collapse headers, tool-filter pills, "show all/less", scroll-to-bottom FAB
- **Config** — command/skill/output-style/plugin/model list actions, hook & sub-agent & MCP forms, filter & project pickers
- **Analytics** — export menu, stat cards, usage gauges
- **Chrome** — sidebar nav, menu bar (stats, session rows, footer), onboarding, About, Settings, Help, keyboard-shortcut overlay
- **Sessions nav** — refresh, sort, clear, project/agent expand toggles

Toggle buttons use state-aware text (e.g. `isExpanded ? "Collapse" : "Expand"`, `isFormatted ? "Show plain text" : "Show formatted"`).

## Notes

- Purely additive — no behaviour, layout, icon, or styling changes.
- Modal/dialog action buttons and dropdown-menu *items* were intentionally skipped (macOS doesn't render hover tooltips on those surfaces); the control that opens them carries the help instead.
- Builds clean (`xcodebuild` Debug/macOS), SwiftLint clean on changed files.
