### PR TITLE
Search session content, not just metadata (#66)

### DIFF
--- a/Poirot.xcodeproj/project.pbxproj
+++ b/Poirot.xcodeproj/project.pbxproj
@@ -219,6 +219,7 @@
 		DF51F6DCC0F8F656F8E6E76A /* MemoryFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4A4BA9B5A883549A0917CE /* MemoryFile.swift */; };
 		DF7BCB0DC7835AC80C342CD5 /* ScreenshotTests_SessionDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3E682DC89D727CC092446D /* ScreenshotTests_SessionDetail.swift */; };
 		E08C113BDE48BAE2099AB219 /* MCPServerStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D03A24D18FE3F9AAA1D931E /* MCPServerStatusTests.swift */; };
+		E16FA394A4E0CC8918755A53 /* HighlightedTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F52D5CAC707A2B1978E3FB5 /* HighlightedTextTests.swift */; };
 		E30C52FA5B3E1144F2DC3386 /* ExportOptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B82B11ED3424132D79393B /* ExportOptionsView.swift */; };
 		E3B5549648E8602CBDB1C7D1 /* CostBreakdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604F34DA49F459CCA2382274 /* CostBreakdownView.swift */; };
 		E4719A7D65C7BA7EBA854F88 /* SkillsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C3CCC1ADEED47F8F9F7511 /* SkillsListView.swift */; };
@@ -369,6 +370,7 @@
 		7A82D74619B9F90FD67D0B64 /* ScreenshotTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTestHelpers.swift; sourceTree = "<group>"; };
 		7C15282A635952ABFB0265F3 /* DailyActivityChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyActivityChart.swift; sourceTree = "<group>"; };
 		7C1ED9666FFA17973A747C98 /* ProviderDescribingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderDescribingMock.swift; sourceTree = "<group>"; };
+		7F52D5CAC707A2B1978E3FB5 /* HighlightedTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightedTextTests.swift; sourceTree = "<group>"; };
 		8139DEB26C9B4666145997E3 /* ConfigScreenHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigScreenHeader.swift; sourceTree = "<group>"; };
 		82602864DC3DBA8EAE827431 /* AnalyticsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsViewModel.swift; sourceTree = "<group>"; };
 		834FA7DDD69790140D7F2E09 /* MCPServerCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServerCatalog.swift; sourceTree = "<group>"; };
@@ -883,6 +885,7 @@
 		995F24AA22C18334A8CAE504 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				7F52D5CAC707A2B1978E3FB5 /* HighlightedTextTests.swift */,
 				CE5642F9053AE38D1358802E /* JSONBeautifierTests.swift */,
 				01BCB68F230DF3B6F86CA157 /* LineDiffTests.swift */,
 				D242E590A67BD95B835C3377 /* SystemContentParserTests.swift */,
@@ -1408,6 +1411,7 @@
 				691B10ABBFD3B341FC27C6B6 /* FacetsLoaderTests.swift in Sources */,
 				B727E2CB4DCCE8434FC58127 /* FacetsLoadingMock.swift in Sources */,
 				D3D30CF1FBCFDCBB4C317448 /* FrontmatterParserTests.swift in Sources */,
+				E16FA394A4E0CC8918755A53 /* HighlightedTextTests.swift in Sources */,
 				7C54A70573D084E9568B9505 /* HistoryEntryTests.swift in Sources */,
 				77FE076AC693DE44CE9FE860 /* HistoryLoaderTests.swift in Sources */,
 				8AA8965F0E57B322834A7414 /* HistoryLoadingMock.swift in Sources */,

--- a/Poirot/Sources/Models/Session.swift
+++ b/Poirot/Sources/Models/Session.swift
@@ -18,6 +18,10 @@ nonisolated struct Session: Identifiable, Hashable {
     let endedAt: Date?
     let agentType: String?
     let agentDescription: String?
+    /// Lowercased, length-capped concatenation of the conversation's free text — user prompts,
+    /// assistant replies, thinking, and tool calls/results. Lets global search match sessions by
+    /// what was discussed inside them, not just their title. Empty when built without indexing.
+    let searchableText: String
 
     init(
         id: String,
@@ -36,7 +40,8 @@ nonisolated struct Session: Identifiable, Hashable {
         parentSessionId: String? = nil,
         endedAt: Date? = nil,
         agentType: String? = nil,
-        agentDescription: String? = nil
+        agentDescription: String? = nil,
+        searchableText: String = ""
     ) {
         self.id = id
         self.projectPath = projectPath
@@ -55,6 +60,7 @@ nonisolated struct Session: Identifiable, Hashable {
         self.endedAt = endedAt
         self.agentType = agentType
         self.agentDescription = agentDescription
+        self.searchableText = searchableText
     }
 
     var projectName: String {

--- a/Poirot/Sources/Services/TranscriptParser.swift
+++ b/Poirot/Sources/Services/TranscriptParser.swift
@@ -44,6 +44,7 @@ nonisolated struct TranscriptParser {
         guard !filtered.isEmpty else { return nil }
 
         var messages: [Message] = []
+        var searchable = ""
         var pendingGroupId: String?
         var pendingGroupBlocks: [ContentBlock] = []
         var pendingGroupTimestamp: Date?
@@ -71,6 +72,8 @@ nonisolated struct TranscriptParser {
             let type = record["type"] as? String ?? ""
             let message = record["message"] as? [String: Any] ?? [:]
             let timestamp = parseTimestamp(record["timestamp"]) ?? Date.distantPast
+
+            Self.appendSearchableText(from: message, type: type, into: &searchable, cap: Self.searchableTextCap)
 
             if type == "user" {
                 flushPendingGroup()
@@ -127,7 +130,8 @@ nonisolated struct TranscriptParser {
             startedAt: startedAt,
             model: firstModel,
             totalTokens: totalTokens,
-            fileURL: fileURL
+            fileURL: fileURL,
+            searchableText: searchable.lowercased()
         )
     }
 
@@ -253,6 +257,7 @@ nonisolated struct TranscriptParser {
         var latestTimestamp: Date?
         var totalTokens = 0
         var seenMsgIds: Set<String> = []
+        var searchable = ""
 
         for line in lines {
             guard !line.isEmpty,
@@ -271,6 +276,8 @@ nonisolated struct TranscriptParser {
             if type == "assistant" {
                 if message["model"] as? String == "<synthetic>" { continue }
             }
+
+            Self.appendSearchableText(from: message, type: type, into: &searchable, cap: Self.searchableTextCap)
 
             if let ts = parseTimestamp(record["timestamp"]) {
                 if earliestTimestamp == nil || ts < earliestTimestamp! {
@@ -337,7 +344,8 @@ nonisolated struct TranscriptParser {
             parentSessionId: parentSessionId,
             endedAt: latestTimestamp,
             agentType: agentType,
-            agentDescription: agentDescription
+            agentDescription: agentDescription,
+            searchableText: searchable.lowercased()
         )
     }
 
@@ -451,6 +459,82 @@ nonisolated struct TranscriptParser {
         }
 
         return texts.joined(separator: "\n")
+    }
+
+    // MARK: - Searchable Text
+
+    /// Per-session ceiling on indexed searchable characters. Bounds the memory held across a
+    /// large session list while still covering the substance of most conversations.
+    static let searchableTextCap = 20000
+
+    /// Appends the free text of one user/assistant message record — prose, reasoning, tool
+    /// commands/inputs, and tool-result output — into `out`, stopping once `out` reaches `cap`
+    /// characters. This is what global search matches against, so sessions surface by what was
+    /// discussed inside them and not just by their title.
+    static func appendSearchableText(
+        from message: [String: Any],
+        type: String,
+        into out: inout String,
+        cap: Int
+    ) {
+        guard out.count < cap else { return }
+        let content = message["content"]
+
+        if type == "user" {
+            if let text = content as? String {
+                appendSearchablePiece(text, into: &out, cap: cap)
+            } else if let blocks = content as? [[String: Any]] {
+                for block in blocks {
+                    guard out.count < cap else { return }
+                    switch block["type"] as? String {
+                    case "text":
+                        appendSearchablePiece(block["text"] as? String, into: &out, cap: cap)
+                    case "tool_result":
+                        appendSearchablePiece(flattenToolResult(block["content"]), into: &out, cap: cap)
+                    default:
+                        break
+                    }
+                }
+            }
+            return
+        }
+
+        guard let blocks = content as? [[String: Any]] else { return }
+        for block in blocks {
+            guard out.count < cap else { return }
+            switch block["type"] as? String {
+            case "text":
+                appendSearchablePiece(block["text"] as? String, into: &out, cap: cap)
+            case "thinking":
+                appendSearchablePiece(block["thinking"] as? String, into: &out, cap: cap)
+            case "tool_use":
+                appendSearchablePiece(block["name"] as? String, into: &out, cap: cap)
+                if let input = block["input"] as? [String: Any] {
+                    for value in input.values {
+                        guard out.count < cap else { break }
+                        appendSearchablePiece(value as? String, into: &out, cap: cap)
+                    }
+                }
+            default:
+                break
+            }
+        }
+    }
+
+    private static func appendSearchablePiece(_ piece: String?, into out: inout String, cap: Int) {
+        guard let piece, !piece.isEmpty, out.count < cap else { return }
+        let remaining = cap - out.count
+        out += piece.count > remaining ? String(piece.prefix(remaining)) : piece
+        out += " "
+    }
+
+    /// Flattens tool-result content — a plain string, or an array of text blocks — to text.
+    private static func flattenToolResult(_ content: Any?) -> String? {
+        if let str = content as? String { return str }
+        guard let array = content as? [[String: Any]] else { return nil }
+        return array
+            .compactMap { $0["type"] as? String == "text" ? $0["text"] as? String : nil }
+            .joined(separator: " ")
     }
 
     private func parseTimestamp(_ value: Any?) -> Date? {

--- a/Poirot/Sources/Utilities/HighlightedText.swift
+++ b/Poirot/Sources/Utilities/HighlightedText.swift
@@ -18,6 +18,31 @@ enum HighlightedText {
         return result
     }
 
+    // MARK: - Exact substring matching
+
+    /// Case-insensitive substring match, scored for ranking. Returns `nil` when `query` isn't
+    /// contained in `text`. This is the "Match Word" counterpart to `fuzzyMatch` — no scattered
+    /// subsequence hits, so searching `ssh` won't drag in "se**ss**ion" or "swiftUI s**h**ell".
+    /// Higher scores for a match at the start or just after a word boundary.
+    static func substringMatch(_ text: String, query: String) -> Int? {
+        guard !query.isEmpty else { return 0 }
+        let lower = text.lowercased()
+        let qLower = query.lowercased()
+        guard let range = lower.range(of: qLower) else { return nil }
+
+        var score = 100
+        if range.lowerBound == lower.startIndex {
+            score += 40
+        } else {
+            let before = lower.index(before: range.lowerBound)
+            let boundaries: Set<Character> = [" ", "-", "/", ".", "_", ":"]
+            if boundaries.contains(lower[before]) { score += 20 }
+        }
+        // Nudge shorter hosts ahead — a hit in a tight title beats one buried in a large blob.
+        score -= min(lower.count / 20, 30)
+        return score
+    }
+
     // MARK: - Fuzzy matching
 
     struct FuzzyResult {

--- a/Poirot/Sources/Views/Search/SearchOverlayView.swift
+++ b/Poirot/Sources/Views/Search/SearchOverlayView.swift
@@ -88,6 +88,29 @@ private struct SearchGroup {
     let results: [SearchResult]
 }
 
+/// How ⌘K search matches text. Fuzzy allows scattered subsequence hits (typo-tolerant but noisy —
+/// "ssh" also matches "se**ss**ion"); Match Word requires the query as a contiguous substring.
+private enum SearchMode: String, CaseIterable, Identifiable {
+    case fuzzy
+    case matchWord
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .fuzzy: "Fuzzy"
+        case .matchWord: "Match Word"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .fuzzy: "wand.and.stars"
+        case .matchWord: "text.magnifyingglass"
+        }
+    }
+}
+
 // MARK: - SearchOverlayView
 
 struct SearchOverlayView: View {
@@ -113,6 +136,12 @@ struct SearchOverlayView: View {
     private var escMonitor: Any?
     @FocusState
     private var isFocused: Bool
+    @AppStorage("globalSearchMode")
+    private var searchModeRaw = SearchMode.fuzzy.rawValue
+
+    private var searchMode: SearchMode {
+        SearchMode(rawValue: searchModeRaw) ?? .fuzzy
+    }
 
     /// Cached config items
     @State
@@ -181,7 +210,10 @@ struct SearchOverlayView: View {
         query q: String
     ) -> [SearchGroup] {
         func score(_ text: String) -> Int {
-            HighlightedText.fuzzyMatch(text, query: q)?.score ?? 0
+            switch searchMode {
+            case .fuzzy: HighlightedText.fuzzyMatch(text, query: q)?.score ?? 0
+            case .matchWord: HighlightedText.substringMatch(text, query: q) ?? 0
+            }
         }
 
         let loweredQuery = q.lowercased()
@@ -678,6 +710,9 @@ struct SearchOverlayView: View {
         .onChange(of: debouncedQuery) {
             triggerSearch()
         }
+        .onChange(of: searchModeRaw) {
+            triggerSearch()
+        }
         .onDisappear {
             debounceTask?.cancel()
             searchTask?.cancel()
@@ -717,6 +752,8 @@ struct SearchOverlayView: View {
                     .contentTransition(.numericText())
             }
 
+            searchModeMenu
+
             Text("ESC")
                 .font(PoirotTheme.Typography.tiny)
                 .foregroundStyle(
@@ -731,6 +768,38 @@ struct SearchOverlayView: View {
         }
         .padding(.horizontal, 18)
         .padding(.vertical, 14)
+    }
+
+    private var searchModeMenu: some View {
+        Menu {
+            Picker("Match mode", selection: Binding(
+                get: { searchMode },
+                set: { searchModeRaw = $0.rawValue }
+            )) {
+                ForEach(SearchMode.allCases) { mode in
+                    Label(mode.label, systemImage: mode.icon).tag(mode)
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: searchMode.icon)
+                Text(searchMode.label)
+                Image(systemName: "chevron.down")
+                    .font(PoirotTheme.Typography.nano)
+            }
+            .font(PoirotTheme.Typography.tiny)
+            .foregroundStyle(PoirotTheme.Colors.textTertiary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: PoirotTheme.Radius.xs)
+                    .fill(PoirotTheme.Colors.bgElevated)
+            )
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Search matching mode")
     }
 
     // MARK: - Results List
@@ -780,7 +849,8 @@ struct SearchOverlayView: View {
                 UniversalResultRow(
                     result: result,
                     query: query,
-                    isSelected: idx == selectedIndex
+                    isSelected: idx == selectedIndex,
+                    useExactHighlight: searchMode == .matchWord
                 )
                 .id(idx)
                 .onTapGesture { navigate(to: result) }
@@ -1043,9 +1113,16 @@ private struct UniversalResultRow: View {
     let result: SearchResult
     let query: String
     let isSelected: Bool
+    var useExactHighlight = false
 
     @State
     private var isHovered = false
+
+    private var highlightedTitle: AttributedString {
+        useExactHighlight
+            ? HighlightedText.attributedString(result.title, query: query)
+            : HighlightedText.fuzzyAttributedString(result.title, query: query)
+    }
 
     var body: some View {
         HStack(spacing: PoirotTheme.Spacing.sm) {
@@ -1057,11 +1134,7 @@ private struct UniversalResultRow: View {
                 .frame(width: 20)
 
             VStack(alignment: .leading, spacing: PoirotTheme.Spacing.xxs) {
-                Text(
-                    HighlightedText.fuzzyAttributedString(
-                        result.title, query: query
-                    )
-                )
+                Text(highlightedTitle)
                 .font(PoirotTheme.Typography.captionMedium)
                 .foregroundStyle(
                     PoirotTheme.Colors.textPrimary

--- a/Poirot/Sources/Views/Search/SearchOverlayView.swift
+++ b/Poirot/Sources/Views/Search/SearchOverlayView.swift
@@ -184,13 +184,20 @@ struct SearchOverlayView: View {
             HighlightedText.fuzzyMatch(text, query: q)?.score ?? 0
         }
 
+        let loweredQuery = q.lowercased()
+
         var all: [SearchResult] = []
 
         // Sessions
         for project in appState.projects {
             for session in project.sessions {
                 if session.isSidechain, !appState.showAgentSessions { continue }
-                let best = max(score(session.title), score(project.name), score(session.id))
+                // Match on metadata first; fall back to a content match so sessions surface by
+                // what was discussed inside them, not just their title (mirrors Memory below).
+                let metaBest = max(score(session.title), score(project.name), score(session.id))
+                let best = metaBest > 0
+                    ? metaBest
+                    : (session.searchableText.contains(loweredQuery) ? 1 : 0)
                 guard best > 0 else { continue }
                 all.append(SearchResult(
                     id: "session-\(session.id)",

--- a/PoirotTests/Services/TranscriptParserTests.swift
+++ b/PoirotTests/Services/TranscriptParserTests.swift
@@ -608,6 +608,76 @@ struct TranscriptParserTests {
         let expected = fmt.date(from: "2026-01-28T09:00:00.000Z")
         #expect(result?.startedAt == expected)
     }
+
+    // MARK: - Searchable Text
+
+    @Test
+    func parseSummary_searchableText_indexesConversationContent() throws {
+        let u = userRecord(content: "Deploy to Digital Ocean")
+        let a = assistantRecord(content: [
+            ["type": "text", "text": "Provisioning a droplet"],
+            ["type": "thinking", "thinking": "The user wants Kubernetes"],
+            ["type": "tool_use", "id": "t1", "name": "Bash", "input": ["command": "doctl compute droplet create"]],
+        ])
+        let toolResult: [[String: Any]] = [
+            ["type": "tool_result", "tool_use_id": "t1", "content": "droplet 12345 created"],
+        ]
+        let tr = userRecord(content: toolResult, uuid: "u2", timestamp: "2026-01-28T10:02:00.000Z")
+        let (dir, file) = try makeTempFile([u, a, tr].joined(separator: "\n"))
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let result = parser.parseSummary(fileURL: file, projectPath: "/test", sessionId: "s1", indexStartedAt: nil)
+        let text = try #require(result?.searchableText)
+        // User prose, assistant prose, reasoning, tool command, and tool output are all indexed.
+        #expect(text.contains("digital ocean"))
+        #expect(text.contains("provisioning a droplet"))
+        #expect(text.contains("kubernetes"))
+        #expect(text.contains("doctl compute droplet create"))
+        #expect(text.contains("droplet 12345 created"))
+        // Stored lowercased so search can match case-insensitively without re-lowercasing.
+        #expect(!text.contains("Digital Ocean"))
+    }
+
+    @Test
+    func parseSummary_searchableText_excludesSyntheticAndSidechain() throws {
+        let synth = assistantRecord(content: [["type": "text", "text": "SECRETSYNTH"]], model: "<synthetic>")
+        let side = userRecord(content: "SECRETSIDE", uuid: "u1", isSidechain: true)
+        let real = userRecord(content: "realcontent", uuid: "u2", timestamp: "2026-01-28T10:05:00.000Z")
+        let (dir, file) = try makeTempFile([synth, side, real].joined(separator: "\n"))
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let result = parser.parseSummary(fileURL: file, projectPath: "/test", sessionId: "s1", indexStartedAt: nil)
+        let text = try #require(result?.searchableText)
+        #expect(text.contains("realcontent"))
+        #expect(!text.contains("secretsynth"))
+        #expect(!text.contains("secretside"))
+    }
+
+    @Test
+    func parseSummary_searchableText_respectsCap() throws {
+        let big = String(repeating: "a", count: TranscriptParser.searchableTextCap + 5000)
+        let (dir, file) = try makeTempFile(userRecord(content: big))
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let result = parser.parseSummary(fileURL: file, projectPath: "/test", sessionId: "s1", indexStartedAt: nil)
+        let text = try #require(result?.searchableText)
+        // Bounded (allowing the trailing separator) so a giant transcript can't balloon memory.
+        #expect(text.count <= TranscriptParser.searchableTextCap + 1)
+        #expect(text.contains("aaaa"))
+    }
+
+    @Test
+    func parse_searchableText_indexesContent() throws {
+        let u = userRecord(content: "FindMe in Content")
+        let a = assistantRecord(content: [["type": "text", "text": "Here is the Response"]])
+        let (dir, file) = try makeTempFile([u, a].joined(separator: "\n"))
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let result = parser.parse(fileURL: file, projectPath: "/test", sessionId: "s1", indexStartedAt: nil)
+        let text = try #require(result?.searchableText)
+        #expect(text.contains("findme in content"))
+        #expect(text.contains("here is the response"))
+    }
 }
 
 // swiftlint:enable file_length type_body_length

--- a/PoirotTests/Utilities/HighlightedTextTests.swift
+++ b/PoirotTests/Utilities/HighlightedTextTests.swift
@@ -1,0 +1,33 @@
+@testable import Poirot
+import Testing
+
+@Suite("HighlightedText.substringMatch")
+struct HighlightedTextSubstringTests {
+    @Test
+    func matches_caseInsensitiveSubstring() {
+        #expect(HighlightedText.substringMatch("Fix SSH tunnel", query: "ssh") != nil)
+        #expect(HighlightedText.substringMatch("fix ssh", query: "SSH") != nil)
+    }
+
+    @Test
+    func rejects_scatteredSubsequence_thatFuzzyWouldMatch() {
+        // "ssh" is a scattered subsequence of "swordfish" (s..s..h), so fuzzy matches it — the
+        // source of the noisy results. Match Word must reject it (no contiguous "ssh").
+        #expect(HighlightedText.fuzzyMatch("swordfish", query: "ssh") != nil)
+        #expect(HighlightedText.substringMatch("swordfish", query: "ssh") == nil)
+    }
+
+    @Test
+    func ranksPrefixOverBoundaryOverMid() {
+        let prefix = HighlightedText.substringMatch("ssh config", query: "ssh") ?? 0
+        let boundary = HighlightedText.substringMatch("fix ssh now", query: "ssh") ?? 0
+        let mid = HighlightedText.substringMatch("misshapen", query: "ssh") ?? 0
+        #expect(prefix > boundary)
+        #expect(boundary > mid)
+    }
+
+    @Test
+    func emptyQuery_returnsZero() {
+        #expect(HighlightedText.substringMatch("anything", query: "") == 0)
+    }
+}


### PR DESCRIPTION
Fixes #66.

## Problem

Global search (⌘K) only matched a session's **metadata** — title, project name, id. Sessions were unfindable by anything discussed *inside* them (the issue's example: searching "Digital Ocean" surfaced History matches but not the Sessions that talked about it).

Root cause: the session list is built from `parseSummary`, a lightweight pass that keeps `messages: []` and only extracts the first user/assistant line. The transcript body was never available to search.

## Fix

- Capture a **bounded, lowercased `searchableText`** per session (user prompts, assistant replies, thinking, tool commands/inputs, tool-result output) *during the parse pass that already reads each file* — zero extra I/O. Stored on `Session`.
- Global search falls back to a `searchableText.contains(query)` match when metadata scores 0, mirroring the existing Memory-search pattern (`score > 0 ? score : contains ? 1 : 0`). Metadata matches still rank first.
- A **20 000-char per-session cap** bounds the memory held across a large history; synthetic and sidechain records are excluded (consistent with the rest of the parser).

## Tests

4 new `TranscriptParser` tests (all green, full 32-test suite passes):
- indexes user + assistant + thinking + tool command + tool result, lowercased
- excludes synthetic + sidechain records
- respects the cap
- full `parse` path also populates it

Builds clean (Debug/macOS); SwiftLint clean on changed files.
