### PR TITLE
Cache the Claude credential so usage refreshes stop re-prompting

### DIFF
--- a/Poirot/Sources/Services/ClaudeCredentialsReader.swift
+++ b/Poirot/Sources/Services/ClaudeCredentialsReader.swift
@@ -46,3 +46,39 @@ nonisolated enum ClaudeCredentialsReader {
         return data
     }
 }
+
+/// In-memory cache for Claude Code's credential so background usage refreshes don't hit the
+/// Keychain — and re-trigger the macOS authorization dialog — on every poll. The Keychain is
+/// read only when the cache is empty or the cached token is about to expire; otherwise the
+/// same token is reused for the rest of its lifetime. On an auth failure the caller invalidates
+/// the cache so the next read picks up a token Claude Code has since rotated.
+actor ClaudeCredentialStore {
+    static let shared = ClaudeCredentialStore()
+
+    /// Re-read slightly before the token's stated expiry so a nearly-dead token is never sent.
+    private static let expiryMargin: TimeInterval = 60
+
+    private let reader: @Sendable () -> ClaudeCredentials?
+    private var cached: ClaudeCredentials?
+
+    init(reader: @escaping @Sendable () -> ClaudeCredentials? = { ClaudeCredentialsReader.read() }) {
+        self.reader = reader
+    }
+
+    /// Returns a usable credential, reading the Keychain only when necessary. Calls made within
+    /// the token's lifetime reuse the cached value and never touch the Keychain (so no prompt).
+    func current(now: Date = Date()) -> ClaudeCredentials? {
+        if let cached, !cached.isExpired(now: now.addingTimeInterval(Self.expiryMargin)) {
+            return cached
+        }
+        let fresh = reader()
+        cached = fresh
+        return fresh
+    }
+
+    /// Drops the cached credential so the next `current()` re-reads the Keychain. Call after an
+    /// authorization failure, when Claude Code has most likely rotated the token.
+    func invalidate() {
+        cached = nil
+    }
+}

--- a/Poirot/Sources/Services/ClaudeUsageLoader.swift
+++ b/Poirot/Sources/Services/ClaudeUsageLoader.swift
@@ -10,7 +10,9 @@ nonisolated struct ClaudeUsageLoader: UsageLoading {
     static let apiVersion = "2023-06-01"
 
     nonisolated func loadUsage() async -> UsageResult {
-        guard let credentials = ClaudeCredentialsReader.read() else {
+        // Reuse the cached credential when possible so repeated background refreshes don't hit
+        // the Keychain — and re-prompt for authorization — on every poll.
+        guard let credentials = await ClaudeCredentialStore.shared.current() else {
             return .unauthenticated
         }
         // Poirot never refreshes tokens; if Claude Code hasn't refreshed its own, surface
@@ -36,6 +38,9 @@ nonisolated struct ClaudeUsageLoader: UsageLoading {
         }
 
         if http.statusCode == 401 || http.statusCode == 403 {
+            // The cached token was rejected — drop it so the next attempt re-reads whatever
+            // credential Claude Code has rotated to.
+            await ClaudeCredentialStore.shared.invalidate()
             return .unauthenticated
         }
         if http.statusCode == 429 {

--- a/PoirotTests/Models/ClaudeCredentialsTests.swift
+++ b/PoirotTests/Models/ClaudeCredentialsTests.swift
@@ -51,3 +51,74 @@ struct ClaudeCredentialsTests {
         #expect(!credentials.isExpired(now: Date(timeIntervalSince1970: 999_999)))
     }
 }
+
+@Suite("ClaudeCredentialStore")
+struct ClaudeCredentialStoreTests {
+    /// Counts how many times the store fell through to an actual credential read. Safe to mutate
+    /// unsynchronized because every call is serialized through the store's actor isolation.
+    private nonisolated final class ReaderSpy: @unchecked Sendable {
+        private(set) var calls = 0
+        private let credential: ClaudeCredentials?
+        init(_ credential: ClaudeCredentials?) { self.credential = credential }
+        func read() -> ClaudeCredentials? {
+            calls += 1
+            return credential
+        }
+    }
+
+    private static func creds(expiresIn seconds: TimeInterval) -> ClaudeCredentials {
+        ClaudeCredentials(
+            accessToken: "tok",
+            expiresAt: Date().addingTimeInterval(seconds),
+            subscriptionType: "max"
+        )
+    }
+
+    @Test
+    func current_readsOnce_whileTokenValid() async {
+        let spy = ReaderSpy(Self.creds(expiresIn: 3600))
+        let store = ClaudeCredentialStore(reader: { spy.read() })
+
+        _ = await store.current()
+        _ = await store.current()
+
+        // Second call is served from cache — no Keychain hit, so no re-prompt.
+        #expect(spy.calls == 1)
+    }
+
+    @Test
+    func current_reReads_whenCachedTokenExpired() async {
+        let spy = ReaderSpy(Self.creds(expiresIn: -10))
+        let store = ClaudeCredentialStore(reader: { spy.read() })
+
+        _ = await store.current()
+        _ = await store.current()
+
+        #expect(spy.calls == 2)
+    }
+
+    @Test
+    func invalidate_forcesReRead() async {
+        let spy = ReaderSpy(Self.creds(expiresIn: 3600))
+        let store = ClaudeCredentialStore(reader: { spy.read() })
+
+        _ = await store.current()
+        await store.invalidate()
+        _ = await store.current()
+
+        #expect(spy.calls == 2)
+    }
+
+    @Test
+    func current_returnsNil_andDoesNotCache_whenNoCredential() async {
+        let spy = ReaderSpy(nil)
+        let store = ClaudeCredentialStore(reader: { spy.read() })
+
+        let first = await store.current()
+        let second = await store.current()
+
+        #expect(first == nil)
+        #expect(second == nil)
+        #expect(spy.calls == 2)
+    }
+}


### PR DESCRIPTION
## Problem

The usage-limits feature re-prompted for Keychain authorization on **every** background refresh (every few minutes). `ClaudeUsageLoader.loadUsage()` called `ClaudeCredentialsReader.read()` on each poll, and that runs `SecItemCopyMatching` against Claude Code's Keychain item — macOS shows its auth dialog on every access unless "Always Allow" was granted (and re-signed dev builds invalidate even that).

## Fix

Add `ClaudeCredentialStore` — an actor that caches the credential in memory and only re-reads the Keychain when the cache is empty or the token is within 60s of expiry. `loadUsage()` now fetches the token through the cache and invalidates it on a 401/403 (so a token Claude Code has rotated gets picked up).

**Net effect:** the Keychain is touched ~once per launch (or per token rotation) instead of once per poll. Background refreshes — and the manual refresh button — no longer prompt.

## Tests

4 new `ClaudeCredentialStore` tests (all green; 28 tests across 3 suites pass):
- reads the Keychain once while the token is valid (second call served from cache)
- re-reads when the cached token has expired
- `invalidate()` forces a re-read
- returns nil and doesn't cache when there's no credential

## Note on the remaining first prompt

This removes the *repeated* prompts. The **first** Keychain read per launch is macOS's cross-app credential security and can't be silenced in code. On a signed/notarized **release** build, clicking **"Always Allow"** persists across launches (stable Developer ID signature). **Debug** builds are re-signed on each rebuild, so they re-prompt after a rebuild — a dev-only artifact end users don't hit.
