### PR TITLE
Make the models list dynamic (curated + session-discovered), incl. Fable

### DIFF
--- a/Poirot.xcodeproj/project.pbxproj
+++ b/Poirot.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		806DAEE620C83C166FE0FB8B /* SearchOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D04D892576D61E453579BC /* SearchOverlayView.swift */; };
 		82406F55ADE53A63C6B028E7 /* ContributionHeatmap.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DF06F9E25D64499D24F01D /* ContributionHeatmap.swift */; };
 		82F43D48A04EE92E2D4EBA97 /* AppStateSessionLoadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC94BCAB321FFC016358C440 /* AppStateSessionLoadingTests.swift */; };
+		83C3B4B8BF1E3317151455B4 /* ClaudeModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0ED5E6349C52B57C4D64229 /* ClaudeModelCatalog.swift */; };
 		84912EEDE77CC32FD9F49152 /* SessionXMLStrippingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA5A7B55EFC02EA5F35FA62 /* SessionXMLStrippingTests.swift */; };
 		84BC06AE4710DF629F88AA4C /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A63E328561222E130E2DDCA /* AppState.swift */; };
 		86685FFB9A926367B757C7D0 /* EditorLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B5E248D52AE2D665186065 /* EditorLauncher.swift */; };
@@ -164,6 +165,7 @@
 		A90884D03F7FCB12F9878672 /* ScreenshotTests_Usage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1707BEA47B5FE47B22DAF443 /* ScreenshotTests_Usage.swift */; };
 		A9D3ACBECA5427C8843C6315 /* AnalyticsDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9507986B99C9DFCFDDA3849 /* AnalyticsDashboardView.swift */; };
 		A9DEEF92D0B0D4B7EBAAB63F /* ClaudeCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D324CA26A994C09E27E8CD0 /* ClaudeCredentials.swift */; };
+		AB5D428A2DA4248E89D8201B /* ClaudeModelCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D4BA557E8665179BB0D487 /* ClaudeModelCatalogTests.swift */; };
 		ACEE72F022EA15935A920B54 /* AnalyticsSnapshotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF86AD00BA8FFAC050DD763 /* AnalyticsSnapshotView.swift */; };
 		AE65BC7796614D7071AFAA83 /* ProjectSortingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB669E6E758B390FBEE0F5C /* ProjectSortingTests.swift */; };
 		AFAB254385F5159CC1251A7D /* ToastOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF446AEF7C49EE8EAB77A84B /* ToastOverlay.swift */; };
@@ -294,6 +296,7 @@
 		2398AF9EC1EE0C8BA32378CD /* MCPServersListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServersListView.swift; sourceTree = "<group>"; };
 		24F9810F9C17BBB0F14C2F45 /* OutputStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputStyle.swift; sourceTree = "<group>"; };
 		26B9CD4BBB58483858519DD3 /* ScreenshotTests_EditDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTests_EditDiff.swift; sourceTree = "<group>"; };
+		29D4BA557E8665179BB0D487 /* ClaudeModelCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeModelCatalogTests.swift; sourceTree = "<group>"; };
 		2CE7A7223D10D8EA0A97C20D /* ClaudeUsageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeUsageTests.swift; sourceTree = "<group>"; };
 		2D324CA26A994C09E27E8CD0 /* ClaudeCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCredentials.swift; sourceTree = "<group>"; };
 		2D48378C53A7352CBE811B97 /* ClaudeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeSettings.swift; sourceTree = "<group>"; };
@@ -457,6 +460,7 @@
 		DD4F57D1DA2A3D3742A92544 /* ScreenshotTests_Facets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTests_Facets.swift; sourceTree = "<group>"; };
 		DE1B5CFE2D4BBFF20308C966 /* ScreenshotTests_Todos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTests_Todos.swift; sourceTree = "<group>"; };
 		DE3AC4EEED07D87A20BA1D6A /* ThinkingBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinkingBlockView.swift; sourceTree = "<group>"; };
+		E0ED5E6349C52B57C4D64229 /* ClaudeModelCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeModelCatalog.swift; sourceTree = "<group>"; };
 		E3FDE64043B69FBEE45996BB /* StatsCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsCache.swift; sourceTree = "<group>"; };
 		E4F2C0308705DE4698DA57E1 /* ToolBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolBlockView.swift; sourceTree = "<group>"; };
 		E56DB0C65DC1F7A2CC463EAD /* AnalyticsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsViewModelTests.swift; sourceTree = "<group>"; };
@@ -615,6 +619,7 @@
 		1D544C9DA5F2B519742B2B60 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				E0ED5E6349C52B57C4D64229 /* ClaudeModelCatalog.swift */,
 				FB118037BF6C6168489D7E8A /* ContextUsage.swift */,
 				F696E190ACB35B6D80853CBB /* DebugLogEntry.swift */,
 				002E3E00599D38883771DDAA /* FileVersion.swift */,
@@ -771,6 +776,7 @@
 			isa = PBXGroup;
 			children = (
 				9818FA0A1812D1C79532263A /* ClaudeCredentialsTests.swift */,
+				29D4BA557E8665179BB0D487 /* ClaudeModelCatalogTests.swift */,
 				2CE7A7223D10D8EA0A97C20D /* ClaudeUsageTests.swift */,
 				9FAD871E07B902D82EB3B0E7 /* ContextUsageTests.swift */,
 				9F1020D92641A5D80E50F44D /* DebugLogEntryTests.swift */,
@@ -1250,6 +1256,7 @@
 				6AEA8D586B62BC7963DB91FE /* ClaudeConfigLoader.swift in Sources */,
 				A9DEEF92D0B0D4B7EBAAB63F /* ClaudeCredentials.swift in Sources */,
 				EB0AACBBF47782BE2AA29FFD /* ClaudeCredentialsReader.swift in Sources */,
+				83C3B4B8BF1E3317151455B4 /* ClaudeModelCatalog.swift in Sources */,
 				72FCF17A2D872F565F4EE2A7 /* ClaudePlugin.swift in Sources */,
 				8C5E9837DF097CF02C1574E8 /* ClaudeSettings.swift in Sources */,
 				8A76B46D06FDB37403D12CAE /* ClaudeSkill.swift in Sources */,
@@ -1400,6 +1407,7 @@
 				D94866039BC8291A7EE450E0 /* ClaudeCodeProviderTests.swift in Sources */,
 				5BA9D35E649A81BA81B1AAD8 /* ClaudeConfigLoaderMCPTests.swift in Sources */,
 				8F90904E938E5E931C3F8726 /* ClaudeCredentialsTests.swift in Sources */,
+				AB5D428A2DA4248E89D8201B /* ClaudeModelCatalogTests.swift in Sources */,
 				EB642D4A993F1B011E3AB659 /* ClaudeUsageTests.swift in Sources */,
 				58488090E2994C9F4D567DBC /* ColorThemeTests.swift in Sources */,
 				15DD32AFC9045E423E70DFA4 /* ContextUsageTests.swift in Sources */,

--- a/Poirot/Sources/Models/ClaudeModelCatalog.swift
+++ b/Poirot/Sources/Models/ClaudeModelCatalog.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// A Claude model as shown on the Models screen: a friendly display name plus optional curated
+/// copy. Models discovered only in session transcripts (not curated) carry an empty description.
+nonisolated struct ClaudeModelInfo: Identifiable, Hashable, Sendable {
+    let displayName: String
+    let description: String
+    let strengths: [String]
+
+    var id: String { displayName }
+
+    init(displayName: String, description: String = "", strengths: [String] = []) {
+        self.displayName = displayName
+        self.description = description
+        self.strengths = strengths
+    }
+}
+
+/// The set of Claude models Poirot shows. Rather than a single hardcoded array, the catalog
+/// combines a curated set of current models — so a new one like Fable appears with a real
+/// description even before you've used it — with any model discovered in your own session
+/// transcripts, so a model you start using shows up on its own. Fully local: no network call and
+/// no `/v1/models` lookup.
+nonisolated enum ClaudeModelCatalog {
+    /// Curated current models, most capable first. The copy is a starting point — tweak freely.
+    static let curated: [ClaudeModelInfo] = [
+        ClaudeModelInfo(
+            displayName: "Opus 4.8",
+            description: "Most capable Claude model for complex reasoning, large-codebase work, and multi-step tasks.",
+            strengths: [
+                "Complex multi-step reasoning",
+                "Large codebase analysis",
+                "Architecture design",
+                "Nuanced debugging",
+            ]
+        ),
+        ClaudeModelInfo(
+            displayName: "Sonnet 5",
+            description: "Balanced speed and capability for everyday coding and conversation.",
+            strengths: [
+                "Fast interactive coding",
+                "Code generation",
+                "Refactoring",
+                "Everyday tasks",
+            ]
+        ),
+        ClaudeModelInfo(
+            displayName: "Haiku 4.5",
+            description: "Fastest, lightest Claude model for quick, low-latency tasks.",
+            strengths: [
+                "Fastest response time",
+                "Simple lookups",
+                "Quick edits",
+                "Low-latency workflows",
+            ]
+        ),
+        ClaudeModelInfo(
+            displayName: "Fable 5",
+            description: "Newest addition to the Claude 5 model family."
+        ),
+    ]
+
+    /// Display names of the curated models — the baseline list used by search and counts.
+    static var curatedNames: [String] { curated.map(\.displayName) }
+
+    /// Model Poirot assumes as the default when none is configured.
+    static let defaultModelName = "Opus 4.8"
+
+    /// Maps a raw session model id to a friendly display name, e.g. `claude-opus-4-8-20260514`
+    /// → `Opus 4.8` and the older `claude-3-5-sonnet-20241022` → `Sonnet 3.5`. Version digits are
+    /// gathered from the short numeric segments (the long date/build stamp is ignored), so it is
+    /// robust to Anthropic's family-first and family-last id orderings. Unknown ids pass through.
+    static func friendlyName(for modelId: String) -> String {
+        let lower = modelId.lowercased()
+        let families = [("opus", "Opus"), ("sonnet", "Sonnet"), ("haiku", "Haiku"), ("fable", "Fable")]
+        guard let (_, label) = families.first(where: { lower.contains($0.0) }) else {
+            return modelId
+        }
+        var stripped = lower
+        if stripped.hasPrefix("claude-") {
+            stripped = String(stripped.dropFirst("claude-".count))
+        }
+        // Short numeric segments are version parts; a >= 6-digit segment is the date/build stamp.
+        let version = stripped
+            .split(separator: "-")
+            .map(String.init)
+            .filter { $0.allSatisfy(\.isNumber) && $0.count < 6 }
+            .joined(separator: ".")
+        return version.isEmpty ? label : "\(label) \(version)"
+    }
+
+    /// The full model list to display: curated models first, then any distinct model found in
+    /// `discoveredIds` that the curated set doesn't already cover (deduped by friendly name).
+    static func models(discoveredIds: [String]) -> [ClaudeModelInfo] {
+        var result = curated
+        var seen = Set(curated.map(\.displayName))
+        for id in discoveredIds where !id.isEmpty {
+            let name = friendlyName(for: id)
+            guard seen.insert(name).inserted else { continue }
+            result.append(ClaudeModelInfo(displayName: name))
+        }
+        return result
+    }
+}

--- a/Poirot/Sources/Services/Providers/ClaudeCodeProvider.swift
+++ b/Poirot/Sources/Services/Providers/ClaudeCodeProvider.swift
@@ -10,8 +10,10 @@ struct ClaudeCodeProvider: ProviderDescribing {
     let projectsPath = "~/.claude/projects"
     let cliPath = "/usr/local/bin/claude"
     let cliLabel = String(localized: "Claude Code Path")
-    let defaultModelName = "Opus 4"
-    let supportedModels = ["Opus 4", "Sonnet 4", "Haiku 3.5"]
+    let defaultModelName = ClaudeModelCatalog.defaultModelName
+    /// Baseline current lineup. The Models screen extends this with models discovered in your
+    /// sessions; see `ClaudeModelCatalog`.
+    var supportedModels: [String] { ClaudeModelCatalog.curatedNames }
 
     let toolDefinitions: [String: ToolDefinition] = [
         "Read": ToolDefinition(displayName: String(localized: "Read"), icon: "doc.text"),
@@ -65,7 +67,7 @@ struct ClaudeCodeProvider: ProviderDescribing {
             icon: "brain.fill",
             iconColor: PoirotTheme.Colors.purple,
             title: String(localized: "Models"),
-            count: "Opus 4",
+            count: ClaudeModelCatalog.defaultModelName,
             description: String(localized: "Default and per-project model preferences"),
             requiredCapability: .models
         ),

--- a/Poirot/Sources/Views/Config/ModelsListView.swift
+++ b/Poirot/Sources/Views/Config/ModelsListView.swift
@@ -15,12 +15,19 @@ struct ModelsListView: View {
     @State
     private var filterQuery = ""
 
-    private var filteredModels: [String] {
+    /// Curated current models plus any model discovered in the loaded sessions. Rebuilt from the
+    /// catalog so newly-used models appear without a hardcoded list going stale.
+    private var allModels: [ClaudeModelInfo] {
+        let discovered = appState.projects.flatMap(\.sessions).compactMap(\.model)
+        return ClaudeModelCatalog.models(discoveredIds: discovered)
+    }
+
+    private var filteredModels: [ClaudeModelInfo] {
         let q = filterQuery.trimmingCharacters(in: .whitespaces)
-        guard !q.isEmpty else { return provider.supportedModels }
-        return provider.supportedModels
-            .compactMap { model -> (String, Int)? in
-                guard let m = HighlightedText.fuzzyMatch(model, query: q) else { return nil }
+        guard !q.isEmpty else { return allModels }
+        return allModels
+            .compactMap { model -> (ClaudeModelInfo, Int)? in
+                guard let m = HighlightedText.fuzzyMatch(model.displayName, query: q) else { return nil }
                 return (model, m.score)
             }
             .sorted { $0.1 > $1.1 }
@@ -31,7 +38,7 @@ struct ModelsListView: View {
         VStack(spacing: 0) {
             ConfigScreenHeader(
                 item: item,
-                dynamicCount: "\(provider.supportedModels.count) \(provider.supportedModels.count == 1 ? "model" : "models")"
+                dynamicCount: "\(allModels.count) \(allModels.count == 1 ? "model" : "models")"
             )
 
             if filteredModels.isEmpty, !filterQuery.isEmpty {
@@ -81,13 +88,13 @@ struct ModelsListView: View {
                         LazyVStack(spacing: PoirotTheme.Spacing.lg) {
                             ForEach(modelsForColumn(column), id: \.element) { index, model in
                                 ModelCard(
-                                    name: model,
+                                    info: model,
                                     filterQuery: filterQuery,
-                                    isDefault: model == (currentDefault ?? provider.defaultModelName),
-                                    isProjectDefault: model == projectModel,
+                                    isDefault: model.displayName == (currentDefault ?? provider.defaultModelName),
+                                    isProjectDefault: model.displayName == projectModel,
                                     hasProject: appState.configProjectPath != nil,
-                                    onSetDefault: { setDefault(model) },
-                                    onSetProjectDefault: { setProjectDefault(model) },
+                                    onSetDefault: { setDefault(model.displayName) },
+                                    onSetProjectDefault: { setProjectDefault(model.displayName) },
                                     onClearProjectDefault: { clearProjectDefault() }
                                 )
                                 .shimmerReveal(
@@ -107,7 +114,7 @@ struct ModelsListView: View {
         .scrollIndicators(.never)
     }
 
-    private func modelsForColumn(_ column: Int) -> [(offset: Int, element: String)] {
+    private func modelsForColumn(_ column: Int) -> [(offset: Int, element: ClaudeModelInfo)] {
         Array(filteredModels.enumerated()).filter { $0.offset % 2 == column }
     }
 
@@ -119,13 +126,13 @@ struct ModelsListView: View {
                 LazyVStack(spacing: PoirotTheme.Spacing.md) {
                     ForEach(Array(filteredModels.enumerated()), id: \.element) { index, model in
                         ModelCard(
-                            name: model,
+                            info: model,
                             filterQuery: filterQuery,
-                            isDefault: model == (currentDefault ?? provider.defaultModelName),
-                            isProjectDefault: model == projectModel,
+                            isDefault: model.displayName == (currentDefault ?? provider.defaultModelName),
+                            isProjectDefault: model.displayName == projectModel,
                             hasProject: appState.configProjectPath != nil,
-                            onSetDefault: { setDefault(model) },
-                            onSetProjectDefault: { setProjectDefault(model) },
+                            onSetDefault: { setDefault(model.displayName) },
+                            onSetProjectDefault: { setProjectDefault(model.displayName) },
                             onClearProjectDefault: { clearProjectDefault() }
                         )
                         .shimmerReveal(
@@ -224,7 +231,7 @@ struct ModelsListView: View {
 // MARK: - Model Card
 
 private struct ModelCard: View {
-    let name: String
+    let info: ClaudeModelInfo
     var filterQuery: String = ""
     let isDefault: Bool
     let isProjectDefault: Bool
@@ -235,36 +242,10 @@ private struct ModelCard: View {
     @State
     private var isHovered = false
 
-    private var modelDescription: String {
-        switch name {
-        case "Opus 4":
-            "Most capable model for complex reasoning, analysis, and multi-step tasks"
-        case "Sonnet 4":
-            "Balanced performance for everyday coding and conversation"
-        case "Haiku 3.5":
-            "Fastest model for quick responses and lightweight tasks"
-        default:
-            ""
-        }
-    }
-
-    private var modelStrengths: [String] {
-        switch name {
-        case "Opus 4":
-            ["Complex multi-step reasoning", "Large codebase analysis", "Architecture design", "Nuanced debugging"]
-        case "Sonnet 4":
-            ["Fast interactive coding", "Code generation", "Refactoring", "Everyday tasks"]
-        case "Haiku 3.5":
-            ["Fastest response time", "Simple lookups", "Quick edits", "Low-latency workflows"]
-        default:
-            []
-        }
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: PoirotTheme.Spacing.sm) {
             HStack(spacing: PoirotTheme.Spacing.sm) {
-                Text(HighlightedText.fuzzyAttributedString(name, query: filterQuery))
+                Text(HighlightedText.fuzzyAttributedString(info.displayName, query: filterQuery))
                     .font(PoirotTheme.Typography.bodyMedium)
                     .foregroundStyle(PoirotTheme.Colors.textPrimary)
 
@@ -297,16 +278,16 @@ private struct ModelCard: View {
                 Spacer()
             }
 
-            if !modelDescription.isEmpty {
-                Text(modelDescription)
+            if !info.description.isEmpty {
+                Text(info.description)
                     .font(PoirotTheme.Typography.caption)
                     .foregroundStyle(PoirotTheme.Colors.textSecondary)
                     .multilineTextAlignment(.leading)
             }
 
-            if !modelStrengths.isEmpty {
+            if !info.strengths.isEmpty {
                 VStack(alignment: .leading, spacing: PoirotTheme.Spacing.xs) {
-                    ForEach(modelStrengths, id: \.self) { strength in
+                    ForEach(info.strengths, id: \.self) { strength in
                         HStack(spacing: PoirotTheme.Spacing.sm) {
                             Image(systemName: "checkmark.circle.fill")
                                 .font(PoirotTheme.Typography.micro)

--- a/PoirotTests/Models/ClaudeModelCatalogTests.swift
+++ b/PoirotTests/Models/ClaudeModelCatalogTests.swift
@@ -1,0 +1,49 @@
+@testable import Poirot
+import Testing
+
+@Suite("ClaudeModelCatalog")
+struct ClaudeModelCatalogTests {
+    @Test
+    func friendlyName_mapsCurrentIds() {
+        #expect(ClaudeModelCatalog.friendlyName(for: "claude-opus-4-8-20260514") == "Opus 4.8")
+        #expect(ClaudeModelCatalog.friendlyName(for: "claude-sonnet-5-20251101") == "Sonnet 5")
+        #expect(ClaudeModelCatalog.friendlyName(for: "claude-haiku-4-5-20251001") == "Haiku 4.5")
+        #expect(ClaudeModelCatalog.friendlyName(for: "claude-fable-5") == "Fable 5")
+    }
+
+    @Test
+    func friendlyName_handlesLegacyOrdering() {
+        // Older ids put the version numbers before the family name.
+        #expect(ClaudeModelCatalog.friendlyName(for: "claude-3-5-sonnet-20241022") == "Sonnet 3.5")
+        #expect(ClaudeModelCatalog.friendlyName(for: "claude-3-opus-20240229") == "Opus 3")
+    }
+
+    @Test
+    func friendlyName_unknownId_passesThrough() {
+        #expect(ClaudeModelCatalog.friendlyName(for: "gpt-4o") == "gpt-4o")
+    }
+
+    @Test
+    func models_includeAllCurated_evenWithNoSessions() {
+        let names = ClaudeModelCatalog.models(discoveredIds: []).map(\.displayName)
+        #expect(names.contains("Fable 5"))
+        #expect(names.contains("Opus 4.8"))
+        #expect(names.count == ClaudeModelCatalog.curated.count)
+    }
+
+    @Test
+    func models_appendDiscovered_withoutDuplicatingCurated() {
+        let models = ClaudeModelCatalog.models(discoveredIds: [
+            "claude-opus-4-8-20260514",   // already curated -> not duplicated
+            "claude-3-5-sonnet-20241022", // discovered -> appended once
+            "claude-3-5-sonnet-20241022", // duplicate -> deduped
+            "",                            // empty -> ignored
+        ])
+        let names = models.map(\.displayName)
+
+        #expect(names.filter { $0 == "Opus 4.8" }.count == 1)
+        #expect(names.filter { $0 == "Sonnet 3.5" }.count == 1)
+        // Curated set plus exactly one newly-discovered model.
+        #expect(names.count == ClaudeModelCatalog.curated.count + 1)
+    }
+}


### PR DESCRIPTION
## Why

The Models screen showed a hardcoded array on the provider — `["Opus 4", "Sonnet 4", "Haiku 3.5"]` — so **Fable 5** (and Opus 4.8 / Sonnet 5 / Haiku 4.5) never appeared. There was no dynamic discovery and no enable/disable state; anything not in that array was simply invisible, and the list went stale.

## What

New **`ClaudeModelCatalog`** — the single source of truth:

- **Curated** current models with descriptions (Opus 4.8, Sonnet 5, Haiku 4.5, Fable 5), so they show *with copy* even before you've used them.
- **`models(discoveredIds:)`** merges in any model found in your loaded **session transcripts** that the curated set doesn't cover — so a model you start using appears on its own. Deduped by friendly name.
- **`friendlyName(for:)`** maps raw ids → display names and handles *both* Anthropic orderings: `claude-opus-4-8-…` → "Opus 4.8" and the legacy `claude-3-5-sonnet-…` → "Sonnet 3.5". Unknown ids pass through.

Wiring:
- `ModelsListView` renders `curated ∪ discovered` (built from `appState` sessions); `ModelCard` takes a `ClaudeModelInfo` instead of switching on a hardcoded name.
- `ClaudeCodeProvider.supportedModels` now derives from the catalog (kills the stale array); default is Opus 4.8.

**No network / no `/v1/models`** — entirely from data Poirot already reads.

## Tests

5 new `ClaudeModelCatalog` tests (all green): id→name mapping (current + legacy orderings), unknown pass-through, curated-always-present, and discovered-merge-with-dedup.

## Notes for you

- The model **descriptions are a starting point** — especially **Fable 5**, which I left minimal ("Newest addition to the Claude 5 model family") rather than invent capabilities I couldn't verify. Tweak freely in `ClaudeModelCatalog.curated`.
- Search (⌘K) and the sidebar count use the curated baseline; the *Models screen* is the one that also adds discovered models. Can extend the others later if you want.
- Left the other ad-hoc model-name formatters (`StatsCache.friendlyModelName`, `ProjectSessionsView`/`SessionsNavigationView.formatModel`) untouched to keep this focused — they're a good follow-up to consolidate onto `ClaudeModelCatalog.friendlyName`.
