### PR TITLE
Fix light-theme readability (search highlight + code syntax colors)

### DIFF
--- a/Poirot/Sources/Theme/PoirotMarkdownTheme.swift
+++ b/Poirot/Sources/Theme/PoirotMarkdownTheme.swift
@@ -94,6 +94,9 @@ struct PoirotCodeBlockView: View {
     @State
     private var attributedCode: AttributedString?
 
+    @Environment(\.colorScheme)
+    private var colorScheme
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if let language = configuration.language {
@@ -127,22 +130,25 @@ struct PoirotCodeBlockView: View {
             RoundedRectangle(cornerRadius: PoirotTheme.Radius.sm)
                 .stroke(PoirotTheme.Colors.border)
         )
-        .task(id: configuration.content) {
+        .task(id: HighlightRequest(content: configuration.content, isDark: colorScheme == .dark)) {
             await highlight(
                 code: configuration.content,
-                language: configuration.language
+                language: configuration.language,
+                isDark: colorScheme == .dark
             )
         }
     }
 
-    private func highlight(code: String, language: String?) async {
+    private func highlight(code: String, language: String?, isDark: Bool) async {
         guard let lang = language else { return }
 
         do {
             let result = try await PoirotHighlight.shared.request(
                 code,
                 mode: .languageAlias(lang),
-                colors: .dark(.xcode)
+                // Match the syntax palette to the appearance — the dark xcode theme's near-white
+                // tokens were unreadable on the light-mode code background.
+                colors: isDark ? .dark(.xcode) : .light(.xcode)
             )
             attributedCode = result.attributedText
         } catch {
@@ -155,4 +161,11 @@ struct PoirotCodeBlockView: View {
 
 private enum PoirotHighlight {
     static let shared = HighlightSwift.Highlight()
+}
+
+/// Keys the syntax-highlight task on both the code and the appearance, so switching light/dark
+/// re-runs the highlighter with the matching palette.
+private struct HighlightRequest: Hashable {
+    let content: String
+    let isDark: Bool
 }

--- a/Poirot/Sources/Utilities/HighlightedText.swift
+++ b/Poirot/Sources/Utilities/HighlightedText.swift
@@ -12,7 +12,9 @@ enum HighlightedText {
             guard let range = result[searchStart ..< result.endIndex].range(of: query, options: .caseInsensitive)
             else { break }
             result[range].backgroundColor = PoirotTheme.Colors.accent.opacity(0.35)
-            result[range].foregroundColor = .white
+            // Theme-adaptive foreground (was hardcoded .white, unreadable on the pale accent
+            // tint in light mode). textPrimary stays legible on the highlight in every theme.
+            result[range].foregroundColor = PoirotTheme.Colors.textPrimary
             searchStart = range.upperBound
         }
         return result
@@ -142,7 +144,7 @@ enum HighlightedText {
             let attrStart = result.index(result.startIndex, offsetByCharacters: offset)
             let attrEnd = result.index(attrStart, offsetByCharacters: 1)
             result[attrStart ..< attrEnd].backgroundColor = PoirotTheme.Colors.accent.opacity(0.35)
-            result[attrStart ..< attrEnd].foregroundColor = .white
+            result[attrStart ..< attrEnd].foregroundColor = PoirotTheme.Colors.textPrimary
         }
         return result
     }


### PR DESCRIPTION
Fixes two light-theme readability bugs.

## Feasibility note (re: copying a7t/chat's theme)

Not needed and not portable. a7t/chat is a React web app whose theming is **CSS** (`tokens.css` / `theme.ts`) — none of it maps to native SwiftUI. Poirot already has a stronger, fully adaptive engine: `ThemePalette` resolves every color to a light/dark hex via a dynamic `NSColor`, across 3 themes and 6 accents. Both bugs were just spots that **bypassed** that engine with hardcoded colors, so the fix routes them back through it — which corrects every theme/accent at once.

## Bugs

1. **Search highlight** — the matched term's background used the accent tint (correct), but the text was hardcoded `.white`. On the pale accent in light mode that was unreadable. → now `PoirotTheme.Colors.textPrimary` (adaptive).
2. **Code blocks** — syntax highlighting always used `.dark(.xcode)`, whose near-white tokens disappeared on the light-mode code background. → now `.light(.xcode)` / `.dark(.xcode)` chosen by `colorScheme`, and the highlighter re-runs when the appearance flips.

## Audit

Swept `Poirot/Sources` for hardcoded `.white` / `.black` / single-hex `Color(hex:)`. Everything else is intentional and correct: the theme/appearance **preview swatches** (which deliberately render fixed theme colors), the search scrim (`Color.black.opacity(0.6)`), the loading shimmer, and the white checkmark on the accent picker. No other real bugs.

## Verify

Builds clean (Debug/macOS), SwiftLint clean. Please eyeball in **light mode**: (a) search inside a session — the highlighted word should be dark-on-tint, readable; (b) open a session with a fenced code block — syntax colors should be dark-on-light, readable. Then confirm dark mode still looks right.
