### PR TITLE
Add Fable 5 capabilities to model catalog

### DIFF
--- a/Poirot/Sources/Models/ClaudeModelCatalog.swift
+++ b/Poirot/Sources/Models/ClaudeModelCatalog.swift
@@ -56,7 +56,13 @@ nonisolated enum ClaudeModelCatalog {
         ),
         ClaudeModelInfo(
             displayName: "Fable 5",
-            description: "Newest addition to the Claude 5 model family."
+            description: "Anthropic's most advanced model for demanding reasoning and long-horizon agentic work.",
+            strengths: [
+                "Ambitious coding projects",
+                "Long-horizon agentic work",
+                "Deep research and analysis",
+                "Document and diagram understanding",
+            ]
         ),
     ]
 


### PR DESCRIPTION
## What

Fable 5 shipped in the dynamic model catalog (#72) with only a placeholder line — "Newest addition to the Claude 5 model family." — and no strengths, so it looked bare next to Opus 4.8, Sonnet 5, and Haiku 4.5 on the Models screen.

This fills in a real description and a 4-item strengths list matching the style of the other curated models.

## Copy

- **Description:** "Anthropic's most advanced model for demanding reasoning and long-horizon agentic work."
- **Strengths:** Ambitious coding projects · Long-horizon agentic work · Deep research and analysis · Document and diagram understanding

Sourced from Anthropic's Fable 5 positioning (product page + model docs): most capable model for ambitious coding/large migrations, multi-day autonomous agentic sessions, deep research → review-ready deliverables, and understanding diagrams/charts/tables in files and PDFs.

## Notes

- Data-only change in `ClaudeModelCatalog.swift`; no new files, no schema change.
- SwiftLint clean; `ClaudeModelCatalogTests` + `ColorThemeTests` pass (16 tests).